### PR TITLE
Add github app to bypass Branch protection rules in GH actions

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -4,13 +4,23 @@ on:
   push:
     branches:
       - dev
+
 jobs:
   bump-version:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
 
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4.1.7
+      - uses: actions/create-github-app-token@v1
+        id: app-token
+        with:
+          app-id: ${{ vars.VERSION_BUMPER_APPID }}
+          private-key: ${{ secrets.VERSION_BUMPER_SECRET }}
+
+      - uses: actions/checkout@v4.1.7
+        with:
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: Set up Node.js
         uses: actions/setup-node@v4.0.3


### PR DESCRIPTION
The changes include a new GH app that can be used as a workaround to bypass branch protection rules.
Currently it's not possible for GH actions to push directly to `dev`.