### PR TITLE
249 Fix Dashboard Issue Mailing Feed wrong width of the items

### DIFF
--- a/apps/frontend/src/pages/Dashboard/Feed/mails/MailList.tsx
+++ b/apps/frontend/src/pages/Dashboard/Feed/mails/MailList.tsx
@@ -40,13 +40,15 @@ const MailList = ({ items, className }: MailListProps) => {
             className="w-min-[300px] flex flex-col items-start gap-2 rounded-lg border p-2 text-left transition-all hover:bg-ciDarkGrey"
           >
             <div className="flex w-full">
-              <span className="text-sm font-semibold">{item.from?.value[0].name || item.from?.value[0].address}</span>
+              <span className="break-all text-sm font-semibold">
+                {item.from?.value[0].name || item.from?.value[0].address}
+              </span>
               <div className="relative mx-2">
                 <p className="absolute h-2 w-2 rounded-full bg-ciLightGreen" />
               </div>
             </div>
-            <p className="text-sm">{item.subject}</p>
-            <p className="line-clamp-2 text-xs text-muted-foreground">{item.text?.substring(0, 300)}</p>
+            <p className="break-all text-sm">{item.subject}</p>
+            <p className="line-clamp-2 break-all text-xs text-muted-foreground">{item.text?.substring(0, 300)}</p>
             {renderLabelBadges(item)}
           </NavLink>
         ))}


### PR DESCRIPTION
Issue: https://github.com/edulution-io/edulution-ui/issues/249

249-MailListRenderIssueDashboard:
* add line breaks with break-all tohandle extreme long words

GIF to prove that the long words cause the render issue:
![20241105_mail-list_render_problem_reason](https://github.com/user-attachments/assets/e38757e3-6c84-4eb7-9ba9-b97711e0f5b2)
