### PR TITLE
Fix language detection on chrome, fixed missing translations

### DIFF
--- a/apps/frontend/src/App.tsx
+++ b/apps/frontend/src/App.tsx
@@ -28,7 +28,7 @@ const App = () => {
     if (user?.language && user.language !== 'system') {
       i18n.changeLanguage(user.language).catch((e) => console.error('Change Language Error', e));
     } else {
-      i18n.changeLanguage(undefined).catch((e) => console.error('Reset to System Language Error', e));
+      i18n.changeLanguage(navigator.language).catch((e) => console.error('Reset to System Language Error', e));
     }
   }, [user?.language]);
 

--- a/apps/frontend/src/locales/en/translation.json
+++ b/apps/frontend/src/locales/en/translation.json
@@ -74,9 +74,9 @@
     "title": "MAIL",
     "sidebar": "Mail",
     "importer": {
-      "title": "E-Mail Importer",
-      "provider": "E-Mail Provider",
-      "configName": "Name der Konfiguration",
+      "title": "Email Importer",
+      "provider": "Email Provider",
+      "configName": "Configuration name",
       "hostname": "Hostname",
       "port": "Port",
       "encryption": "Encryption",
@@ -85,7 +85,7 @@
       "syncJobsTable": "Importer Jobs",
       "rowsSelected": "{{selected}} of {{total}} jobs selected",
       "rowSelected": "{{selected}} of {{total}} job selected",
-      "mailAddress": "E-Mail Address"
+      "mailAddress": "Email address"
     }
   },
   "chat": {
@@ -529,7 +529,7 @@
       }
     },
     "mails": {
-      "title": "E-Mail"
+      "title": "Email"
     },
     "faq": "FAQ",
     "externalIntegration": "External Integration",
@@ -645,7 +645,7 @@
     "not-available": "Not available",
     "date": "Date",
     "time": "Time",
-    "revert": "Zurücksetzen"
+    "revert": "Revert"
   },
   "form": {
     "path": "Path",
@@ -809,8 +809,8 @@
   "accountData": {
     "account_info": "Account Information",
     "name": "Name",
-    "email": "E-Mail",
-    "school": "Schule",
+    "email": "Email",
+    "school": "School",
     "role": "Role",
     "classes": "Classes",
     "change_password": "Change Password",
@@ -852,7 +852,7 @@
       "NotAbleToLockMailboxError": "Could not lock on to the mailbox",
       "NotAbleToFetchMailsError": "Could not fetch mails",
       "NotValidPortTypeError": "The port must be specified as a number",
-      "MailProviderNotFound": "E-Mail provider not found",
+      "MailProviderNotFound": "Email provider not found",
       "MailcowApiGetSyncJobsFailed": "Not able to get sync jobs",
       "MailcowApiCreateSyncJobFailed": "Not able to create sync job",
       "MailcowApiDeleteSyncJobsFailed": "Not able to delete sync jobs"


### PR DESCRIPTION
- Fixed the fallback language, chrome uses the html lang="en", which is defined in the index.html.
- Add some missing translations