### PR TITLE
Fix-webdav-cert-check

### DIFF
--- a/apps/api/src/filesharing/webdav.client.factory.ts
+++ b/apps/api/src/filesharing/webdav.client.factory.ts
@@ -1,14 +1,21 @@
 import axios from 'axios';
+import https from 'https';
 
 class WebdavClientFactory {
   static createWebdavClient(baseUrl: string, username: string, password: string) {
     const token = Buffer.from(`${username}:${password}`).toString('base64');
+
+    const httpsAgent = new https.Agent({
+      rejectUnauthorized: false,
+    });
+
     return axios.create({
       baseURL: baseUrl,
       headers: {
         'Content-Type': 'application/xml',
         Authorization: `Basic ${token}`,
       },
+      httpsAgent,
     });
   }
 }


### PR DESCRIPTION
Add ignore cert check for webdav. On installer deployment, webdav url is served as IP address, so cert check always fails.