### PR TITLE
Fix navigating to settings page

### DIFF
--- a/apps/frontend/src/pages/Settings/AppConfig/AddAppConfigDialog.tsx
+++ b/apps/frontend/src/pages/Settings/AppConfig/AddAppConfigDialog.tsx
@@ -68,10 +68,10 @@ const AddAppConfigDialog: React.FC<AddAppConfigDialogProps> = ({ option, setOpti
   };
 
   useEffect(() => {
-    if (!isAddAppConfigDialogOpen) {
-      navigate(selectedOption ? `/${SETTINGS_PATH}/${selectedOption}` : `/${SETTINGS_PATH}`, { replace: true });
+    if (selectedOption && !isAddAppConfigDialogOpen) {
+      navigate(`/${SETTINGS_PATH}/${selectedOption}`);
     }
-  }, [isAddAppConfigDialogOpen, setIsAddAppConfigDialogOpen]);
+  }, [isAddAppConfigDialogOpen, selectedOption]);
 
   const dialogFooter = (
     <div className="mt-4 flex justify-end">

--- a/apps/frontend/src/pages/Settings/AppConfig/AppConfigPage.tsx
+++ b/apps/frontend/src/pages/Settings/AppConfig/AppConfigPage.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { useLocation, useNavigate } from 'react-router-dom';
+import { useNavigate, useParams } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import { useForm, UseFormReturn } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
@@ -31,20 +31,15 @@ import formSchema from './appConfigSchema';
 import ProxyConfigForm from './components/ProxyConfigForm';
 
 const AppConfigPage: React.FC = () => {
-  const { pathname } = useLocation();
+  const { settingLocation = '' } = useParams<{ settingLocation: string }>();
+
   const { t } = useTranslation();
   const navigate = useNavigate();
   const { appConfigs, setIsDeleteAppConfigDialogOpen, updateAppConfig, deleteAppConfigEntry } = useAppConfigsStore();
   const { searchGroups } = useGroupStore();
   const [option, setOption] = useState('');
-  const [settingLocation, setSettingLocation] = useState('');
   const isMobileView = useIsMobileView();
   const { postExternalMailProviderConfig } = useMailsStore();
-
-  useEffect(() => {
-    const selectedAppConfig = pathname.split('/').filter((p) => p)[1] || '';
-    setSettingLocation(pathname === `/${SETTINGS_PATH}` ? '' : selectedAppConfig);
-  }, [pathname]);
 
   const form = useForm<{ [settingLocation: string]: AppConfigDto | string } | ProxyConfigFormType>({
     mode: 'onChange',
@@ -245,7 +240,6 @@ const AppConfigPage: React.FC = () => {
   const handleDeleteSettingsItem = async () => {
     const deleteOptionName = appConfigs.filter((item) => item.name === settingLocation)[0].name;
 
-    setSettingLocation('');
     navigate(`/${SETTINGS_PATH}`);
 
     await deleteAppConfigEntry(deleteOptionName);

--- a/apps/frontend/src/router/CreateRouter.tsx
+++ b/apps/frontend/src/router/CreateRouter.tsx
@@ -15,7 +15,6 @@ import getAuthRoutes from '@/router/routes/AuthRoutes';
 import getClassManagementRoutes from '@/router/routes/ClassManagementRoutes';
 import { HomePage } from '@/pages/Home';
 import NativeAppPage from '@/pages/NativeAppPage/NativeAppPage';
-import AppConfigPage from '@/pages/Settings/AppConfig/AppConfigPage';
 import UserSettingsMailsPage from '@/pages/UserSettings/Mails/UserSettingsMailsPage';
 import UserSettingsDetailsPage from '@/pages/UserSettings/Details/UserSettingsDetailsPage';
 import UserSettingsSecurityPage from '@/pages/UserSettings/Security/UserSettingsSecurityPage';
@@ -25,7 +24,6 @@ import FileViewer from '@/pages/FileSharing/previews/FileViewer';
 import EmptyLayout from '@/components/layout/EmptyLayout';
 import MainLayout from '@/components/layout/MainLayout';
 import getPublicRoutes from '@/router/routes/PublicRoutes';
-import { SETTINGS_PATH } from '@libs/appconfig/constants/appConfigPaths';
 import getSettingsRoutes from './routes/SettingsRoutes';
 import getForwardedRoutes from './routes/ForwardedRoutes';
 import getEmbeddedRoutes from './routes/EmbeddedRoutes';
@@ -79,20 +77,6 @@ const createRouter = (isAuthenticated: boolean, appConfigs: AppConfigDto[]) => {
                   element={<LanguageSettingsPage />}
                 />
               </Route>
-              {isSuperAdmin ? (
-                <Route
-                  path={SETTINGS_PATH}
-                  element={<AppConfigPage />}
-                >
-                  {appConfigs.map((item) => (
-                    <Route
-                      key={item.name}
-                      path={item.name}
-                      element={<AppConfigPage />}
-                    />
-                  ))}
-                </Route>
-              ) : null}
               {appConfigs.map((item) =>
                 item.appType === APP_INTEGRATION_VARIANT.NATIVE ? (
                   <Route
@@ -103,7 +87,7 @@ const createRouter = (isAuthenticated: boolean, appConfigs: AppConfigDto[]) => {
                 ) : null,
               )}
               {getClassManagementRoutes()}
-              {getSettingsRoutes(appConfigs)}
+              {isSuperAdmin && getSettingsRoutes()}
             </Route>
           </>
         ) : null}

--- a/apps/frontend/src/router/routes/SettingsRoutes.tsx
+++ b/apps/frontend/src/router/routes/SettingsRoutes.tsx
@@ -1,22 +1,18 @@
 import React from 'react';
 import { Route } from 'react-router-dom';
 import AppConfigPage from '@/pages/Settings/AppConfig/AppConfigPage';
-import { AppConfigDto } from '@libs/appconfig/types';
 import { SETTINGS_PATH } from '@libs/appconfig/constants/appConfigPaths';
 
-const getSettingsRoutes = (appConfigs: AppConfigDto[]) => [
+const getSettingsRoutes = () => [
   <Route
     key={SETTINGS_PATH}
     path={SETTINGS_PATH}
     element={<AppConfigPage />}
   >
-    {appConfigs.map((item) => (
-      <Route
-        key={item.name}
-        path={item.name}
-        element={<AppConfigPage />}
-      />
-    ))}
+    <Route
+      path=":settingLocation"
+      element={<AppConfigPage />}
+    />
   </Route>,
 ];
 


### PR DESCRIPTION
There was a bug, for example when clicking on "manage categories" on bulletin board dropdown menu. 
![grafik](https://github.com/user-attachments/assets/d868e5b8-c1ba-43fc-87ea-eb85b07bb97c)
You were navigated to `settings/bulletinboard` but after 0.5s you are redirected to `settings/`.


The actual bug was caused by the `<AddAppConfigDialog />` useffect, other changes are clean up.