### PR TITLE
Fix bulletin board layout issues

### DIFF
--- a/apps/frontend/src/pages/BulletinBoard/components/BulletinBoardColumnItem.tsx
+++ b/apps/frontend/src/pages/BulletinBoard/components/BulletinBoardColumnItem.tsx
@@ -126,8 +126,10 @@ const BulletinBoardColumnItem = ({
       key={bulletin.id}
       className="relative flex items-center justify-between break-all rounded-lg bg-white bg-opacity-5 p-4"
     >
-      <div className="flex-1">
-        <h4 className="truncate text-lg font-bold text-white">{bulletin.title}</h4>
+      <div className="w-full flex-1">
+        <h4 className="w-[calc(100%-20px)] overflow-x-hidden break-normal text-lg font-bold text-white">
+          {bulletin.title}
+        </h4>
         <div className="mt-2 text-gray-100">
           {bulletin.content.split(/(<img[^>]*>)/g).map((part) => getProcessedBulletinContent(part))}
         </div>

--- a/apps/frontend/src/pages/BulletinBoard/components/BulletinBoardColumnItem.tsx
+++ b/apps/frontend/src/pages/BulletinBoard/components/BulletinBoardColumnItem.tsx
@@ -127,7 +127,7 @@ const BulletinBoardColumnItem = ({
       className="relative flex items-center justify-between break-all rounded-lg bg-white bg-opacity-5 p-4"
     >
       <div className="w-full flex-1">
-        <h4 className="w-[calc(100%-20px)] overflow-x-hidden break-normal text-lg font-bold text-white">
+        <h4 className="w-[calc(100%-20px)] overflow-x-hidden text-ellipsis break-normal text-lg font-bold text-white">
           {bulletin.title}
         </h4>
         <div className="mt-2 text-gray-100">

--- a/apps/frontend/src/pages/BulletinBoard/components/BulletinBoardPageColumn.tsx
+++ b/apps/frontend/src/pages/BulletinBoard/components/BulletinBoardPageColumn.tsx
@@ -46,7 +46,7 @@ const BulletinBoardPageColumn = ({
         category={category}
         canEditCategory={canEditCategory}
       />
-      <div className="flex flex-col gap-4 overflow-y-auto pb-20 text-white">
+      <div className="flex flex-col gap-4 overflow-y-auto pb-20 text-white scrollbar-thin">
         {bulletins.map((bulletin) => (
           <BulletinBoardColumnItem
             key={bulletin.id}


### PR DESCRIPTION
I could not reproduce the initial problem (seems to be fixed on schulungs env). But found other issues:

Before:
![grafik](https://github.com/user-attachments/assets/6b094335-01cd-4891-8834-8d01a8c9b76e)

So I changed the title classnames:
After:
![grafik](https://github.com/user-attachments/assets/258c5d90-9b36-4782-be20-068cbf2d71bb)
