### PR TITLE
Customize Sonner toaster

### DIFF
--- a/apps/frontend/src/components/ui/Sonner.tsx
+++ b/apps/frontend/src/components/ui/Sonner.tsx
@@ -19,6 +19,7 @@ const Toaster = ({ ...props }: ToasterProps) => {
         duration: 4000,
         classNames: {
           toast: 'group toast group-[.toaster]:bg-foreground group-[.toaster]:border-border group-[.toaster]:shadow-lg',
+          content: 'group-[.toaster]:text-background',
         },
       }}
       richColors

--- a/apps/frontend/src/components/ui/Sonner.tsx
+++ b/apps/frontend/src/components/ui/Sonner.tsx
@@ -13,15 +13,15 @@ const Toaster = ({ ...props }: ToasterProps) => {
     <Sonner
       theme={theme as ToasterProps['theme']}
       className="toaster group"
+      closeButton
+      offset={60}
       toastOptions={{
+        duration: 4000,
         classNames: {
-          toast:
-            'group toast group-[.toaster]:bg-background group-[.toaster]:text-foreground group-[.toaster]:border-border group-[.toaster]:shadow-lg',
-          description: 'group-[.toast]:text-muted-foreground',
-          actionButton: 'group-[.toast]:bg-primary group-[.toast]:text-primary-foreground',
-          cancelButton: 'group-[.toast]:bg-muted group-[.toast]:text-muted-foreground',
+          toast: 'group toast group-[.toaster]:bg-foreground group-[.toaster]:border-border group-[.toaster]:shadow-lg',
         },
       }}
+      richColors
       {...props}
     />
   );


### PR DESCRIPTION
### Changed

- [x] Added close button (it was not possible to change the close button's position an easy way)
- [x] Increased the offset to the border on desktop view (does not overflow user settings button anymore)
- [x] Removed unused classNames
- [x] Added a default duration to make it ALWAYS disappear after a while
- [x] Changed to a dark color (`bg-foreground`)
- [x] Enabled rich colors for the text and icon
![grafik](https://github.com/user-attachments/assets/6e83086e-ad02-481f-9c60-ba904589dfd0)
![grafik](https://github.com/user-attachments/assets/7324f630-a59f-4bfa-be07-68f01835b003)
![grafik](https://github.com/user-attachments/assets/a99e915a-269c-4188-9356-1b9e6c973a2f)

### Unchaged

- [ ] Grouping toasts (identical toasts are not grouped to one toast, this needs an extra middleware). Maybe we can postpone it...

Since the toasts are not expanded when they are displayed I think its not so bad. Moreover this behavior should be used by us devs to track down places where this happens to refactor a multiple displaying of the toasters.

### Mobile view
I changed the colors of the content after making this screenshot. The text is white now:
![grafik](https://github.com/user-attachments/assets/a0a39556-9fe8-431f-9330-318f4604eb35)
