### PR TITLE
Reduce logging for appconfig migrations

### DIFF
--- a/apps/api/src/appconfig/migrations/migration000.ts
+++ b/apps/api/src/appconfig/migrations/migration000.ts
@@ -10,15 +10,15 @@ const migration000: Migration<MigrationModels> = {
 
     const unprocessedDocuments = await model.find({ schemaVersion: previousSchemaVersion });
     if (unprocessedDocuments.length === 0) {
-      Logger.log('No documents to update');
       return;
     }
+    Logger.log(`${unprocessedDocuments?.length} documents to update...`);
 
     // eslint-disable-next-line no-underscore-dangle
     const ids = unprocessedDocuments.map((doc) => doc._id);
 
-    await model.updateMany({ _id: { $in: ids } }, { $set: { schemaVersion: newSchemaVersion } });
-    Logger.log(`Migration completed: ${unprocessedDocuments.length} documents updated`);
+    const result = await model.updateMany({ _id: { $in: ids } }, { $set: { schemaVersion: newSchemaVersion } });
+    Logger.log(`Migration completed: ${result.modifiedCount} documents updated`);
   },
 };
 

--- a/apps/api/src/appconfig/migrations/migration001.ts
+++ b/apps/api/src/appconfig/migrations/migration001.ts
@@ -20,10 +20,10 @@ const migration001: Migration<MigrationModels> = {
       return;
     }
 
-    const isOldExtendedOptionsValid = (extendedOptions: ExtendedOption[]) => {
-      if (!Array.isArray(extendedOptions)) return false;
-      return true;
-    };
+    const isOldExtendedOptionsValid = (extendedOptions: ExtendedOption[]) => Array.isArray(extendedOptions);
+    const isExtendedOptionsAValidObject = (extendedOptions: ExtendedOption[]) => typeof extendedOptions === 'object';
+
+    let processedDocumentsCount = 0;
 
     await Promise.all(
       unprocessedDocuments.map(async (doc) => {
@@ -31,7 +31,9 @@ const migration001: Migration<MigrationModels> = {
 
         const oldExtendedOptions = doc.extendedOptions as ExtendedOption[];
         if (!isOldExtendedOptionsValid(oldExtendedOptions)) {
-          Logger.warn(`Skipping document ${id} due to invalid extendedOptions format`);
+          if (!isExtendedOptionsAValidObject(oldExtendedOptions)) {
+            Logger.warn(`Skipping document ${id} due to invalid extendedOptions format`);
+          }
           return;
         }
 
@@ -51,6 +53,8 @@ const migration001: Migration<MigrationModels> = {
               },
             },
           );
+
+          processedDocumentsCount += 1;
           Logger.log(`Document ${id} updated successfully`);
         } catch (error) {
           Logger.error(`Failed to update document ${id}: ${(error as Error).message}`);
@@ -58,7 +62,9 @@ const migration001: Migration<MigrationModels> = {
       }),
     );
 
-    Logger.log(`Migration completed: ${unprocessedDocuments.length} documents updated`);
+    if (processedDocumentsCount > 0) {
+      Logger.log(`Migration completed: ${processedDocumentsCount} documents updated`);
+    }
   },
 };
 


### PR DESCRIPTION
Before:
![grafik](https://github.com/user-attachments/assets/af2adea7-0b4f-4b97-add2-7e02820f2dc5)


---------------
After: 
![grafik](https://github.com/user-attachments/assets/436a4cf9-5ca4-4e3d-915e-41287bc7293d)

------------------
With successful migration:
![grafik](https://github.com/user-attachments/assets/aa69c0d6-e701-4cce-9d15-dc6b9cd2cf25)

