### PR TITLE
Configure the API Project’s Webpack Build to Enable Debugging

### DIFF
--- a/apps/api/project.json
+++ b/apps/api/project.json
@@ -12,6 +12,23 @@
         "fix": true
       }
     },
+
+    "build": {
+      "executor": "@nx/webpack:webpack",
+      "options": {
+        "webpackConfig": "apps/api/webpack.config.js",
+        "outputPath": "dist/apps/api"
+      },
+      "configurations": {
+        "development": {
+          "sourceMap": true
+        },
+        "production": {
+          "sourceMap": false
+        }
+      }
+    },
+
     "serve": {
       "executor": "@nx/js:node",
       "defaultConfiguration": "development",

--- a/apps/api/webpack.config.js
+++ b/apps/api/webpack.config.js
@@ -2,8 +2,10 @@ const { NxWebpackPlugin } = require('@nx/webpack');
 const { join } = require('path');
 
 module.exports = {
+  devtool: 'source-map',
   output: {
     path: join(__dirname, '../../dist/apps/api'),
+    sourceMapFilename: '[name].js.map',
   },
   module: {
     rules: [
@@ -13,6 +15,7 @@ module.exports = {
       },
     ],
   },
+
   plugins: [
     new NxWebpackPlugin({
       target: 'node',


### PR DESCRIPTION
Introduced a Webpack-based build setup for the API project using @nx/webpack. Configurations for development and production builds were added, with source maps enabled for development. Updated the Webpack config file to support source map generation and adjusted the output settings.