### PR TITLE
355: Survey Test: Fix the thrown error

### DIFF
--- a/apps/api/src/surveys/survey-answer.service.spec.ts
+++ b/apps/api/src/surveys/survey-answer.service.spec.ts
@@ -210,9 +210,9 @@ describe('SurveyAnswerService', () => {
       surveyModel.find = jest.fn().mockReturnValue([openSurvey01, openSurvey02]);
 
       const currentDate = new Date();
-      const result = await service.getOpenSurveys(firstMockJWTUser);
+      const result = await service.getOpenSurveys(firstMockJWTUser, currentDate);
       expect(result).toEqual([openSurvey01, openSurvey02]);
-      expect(service.getOpenSurveys).toHaveBeenCalledWith(firstMockJWTUser);
+      expect(service.getOpenSurveys).toHaveBeenCalledWith(firstMockJWTUser, currentDate);
 
       expect(surveyModel.find).toHaveBeenCalledWith({
         $or: [

--- a/apps/api/src/surveys/survey-answer.service.ts
+++ b/apps/api/src/surveys/survey-answer.service.ts
@@ -93,8 +93,7 @@ class SurveyAnswersService {
     return createdSurveys || [];
   }
 
-  async getOpenSurveys(user: JWTUser): Promise<Survey[]> {
-    const currentDate = new Date();
+  async getOpenSurveys(user: JWTUser, currentDate: Date = new Date()): Promise<Survey[]> {
     const query = {
       $or: [
         {


### PR DESCRIPTION
(child) 355: * fix the test that did throw an error because the time is not synced to the tests