### PR TITLE
[Filesharing] Add WEBP to supported image extensions

### DIFF
--- a/libs/src/filesharing/types/imageExtensions.ts
+++ b/libs/src/filesharing/types/imageExtensions.ts
@@ -15,6 +15,7 @@ enum ImageExtensions {
   JPEG = 'jpeg',
   JPG = 'jpg',
   GIF = 'gif',
+  WEBP = 'webp',
 }
 
 export default ImageExtensions;


### PR DESCRIPTION
This update includes WEBP in the list of supported image extensions in the ImageExtensions enum. It ensures compatibility with files using the WEBP format.