### PR TITLE
527 - Survey Page - Filter not working

### DIFF
--- a/apps/frontend/src/pages/Surveys/Tables/components/SurveyTableColumns.tsx
+++ b/apps/frontend/src/pages/Surveys/Tables/components/SurveyTableColumns.tsx
@@ -45,6 +45,7 @@ const SurveyTableColumns: ColumnDef<SurveyDto>[] = [
         onClick={() => row.toggleSelected()}
       />
     ),
+    accessorFn: (row) => row.formula.title,
     sortingFn: (rowA, rowB) => sortSurveyByTitle(rowA.original, rowB.original),
   },
   {


### PR DESCRIPTION
Issue: https://github.com/edulution-io/edulution-ui/issues/527

527:
 * add the accessorKey to the title cell such that the right values are filtered