### PR TITLE
530 - Survey Creator - matrix could exceed the available space (should add a scrolling mechanism)

### DIFF
--- a/apps/frontend/src/pages/Surveys/theme/custom.creator.css
+++ b/apps/frontend/src/pages/Surveys/theme/custom.creator.css
@@ -324,7 +324,7 @@
   .svc-question__adorner,
   .svc-question__adorner--collapse-never,
   .svc-question__content {
-    background-color: rgba(0, 0, 0, 0.4) !important;
+    background-color: var(--foreground) !important;
   }
 
   .svc-btn {
@@ -414,9 +414,15 @@
     color: var(--primary-foreground);
   }
 
-  /* fixes white color on matrices first cells  */
-  .sd-matrix tr > td {
-    background-color: transparent;
+  .sd-question--table > .sd-question__content {
+    min-width: 100%;
+    max-width: 100%;
+  }
+  .sd-table__cell--empty,
+  .sd-matrix tr > td:first-of-type,
+  .sd-table__cell--row-text:first-of-type {
+    background-color: var(--foreground) !important;
+    padding-left: 16px;
   }
 
   .svc-matrix-cell .sd-dropdown--empty {


### PR DESCRIPTION
Issue: https://github.com/edulution-io/edulution-ui/issues/530

530:
* fix the overflow mechanism for the matrix content
    * fix the matrix content width 
    * fix the background for the sticky cells and the question background sucht that the labels keep readable

BEFORE: 
![20250319_SurveyCreator_MatrixOverflow_Before](https://github.com/user-attachments/assets/bb875a45-4a8a-451c-91f7-876ac94029bf)

AFTER:
![20250319_SurveyCreator_MatrixOverflow_After](https://github.com/user-attachments/assets/cc4027c1-2728-4fff-876f-81657b30c215)