### PR TITLE
606 - Survey Participation: Rating component should show stars

### DIFF
--- a/apps/frontend/src/pages/Surveys/Participation/SurveyParticipationPage.tsx
+++ b/apps/frontend/src/pages/Surveys/Participation/SurveyParticipationPage.tsx
@@ -12,7 +12,7 @@
 
 import React, { useEffect, useMemo } from 'react';
 import { toast } from 'sonner';
-import { Model } from 'survey-core';
+import { Model, Serializer } from 'survey-core';
 import { Survey } from 'survey-react-ui';
 import { useParams } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
@@ -27,6 +27,8 @@ import '../theme/custom.participation.css';
 interface SurveyParticipationPageProps {
   isPublic: boolean;
 }
+
+Serializer.getProperty('rating', 'displayMode').defaultValue = 'buttons';
 
 const SurveyParticipationPage = (props: SurveyParticipationPageProps): React.ReactNode => {
   const { isPublic = false } = props;

--- a/apps/frontend/src/pages/Surveys/theme/custom.creator.css
+++ b/apps/frontend/src/pages/Surveys/theme/custom.creator.css
@@ -324,7 +324,7 @@
   .svc-question__adorner,
   .svc-question__adorner--collapse-never,
   .svc-question__content {
-    background-color: var(--foreground) !important;
+    background-color: rgba(0, 0, 0, 0.4) !important;
   }
 
   .svc-btn {
@@ -414,15 +414,9 @@
     color: var(--primary-foreground);
   }
 
-  .sd-question--table > .sd-question__content {
-    min-width: 100%;
-    max-width: 100%;
-  }
-  .sd-table__cell--empty,
-  .sd-matrix tr > td:first-of-type,
-  .sd-table__cell--row-text:first-of-type {
-    background-color: var(--foreground) !important;
-    padding-left: 16px;
+  /* fixes white color on matrices first cells  */
+  .sd-matrix tr > td {
+    background-color: transparent;
   }
 
   .svc-matrix-cell .sd-dropdown--empty {


### PR DESCRIPTION
Issue: https://github.com/edulution-io/edulution-ui/issues/606

606
* survey participation rating items should be displayed as stars

Before:
![20250319_SurveyParticipation_RatingItems_Before](https://github.com/user-attachments/assets/487e7c34-fe00-4654-a937-89ae69884b6f)

After:
![20250319_SurveyParticipation_RatingItems_After](https://github.com/user-attachments/assets/a1c6333e-13b4-4887-8ed9-f3efbbdd03ea)
