### PR TITLE
496 - Survey: Track users name when participating

### DIFF
--- a/apps/api/src/surveys/public-surveys.controller.spec.ts
+++ b/apps/api/src/surveys/public-surveys.controller.spec.ts
@@ -27,6 +27,7 @@ import PublicSurveysController from './public-surveys.controller';
 import {
   filteredChoices,
   filteredChoicesAfterAddingValidAnswer,
+  firstMockUser,
   idOfPublicSurvey01,
   idOfPublicSurvey02,
   mockedValidAnswerForPublicSurveys02,
@@ -113,6 +114,7 @@ describe(PublicSurveysController.name, () => {
     it('should call the addAnswerToPublicSurvey() function of the surveyAnswerService', async () => {
       jest.spyOn(surveyAnswerService, 'addAnswer');
 
+      surveyAnswerModel.findOne = jest.fn().mockResolvedValueOnce(null);
       surveyModel.findById = jest.fn().mockResolvedValueOnce(publicSurvey02);
 
       surveyAnswerModel.create = jest.fn().mockResolvedValueOnce(surveyValidAnswerPublicSurvey02);
@@ -122,12 +124,14 @@ describe(PublicSurveysController.name, () => {
         surveyId: idOfPublicSurvey02.toString(),
         saveNo: saveNoPublicSurvey02,
         answer: mockedValidAnswerForPublicSurveys02,
+        userInfo: { preferred_username: firstMockUser.username },
       });
 
       expect(surveyAnswerService.addAnswer).toHaveBeenCalledWith(
         idOfPublicSurvey02.toString(),
         saveNoPublicSurvey02,
         mockedValidAnswerForPublicSurveys02,
+        { preferred_username: firstMockUser.username },
       );
     });
 

--- a/apps/api/src/surveys/public-surveys.controller.ts
+++ b/apps/api/src/surveys/public-surveys.controller.ts
@@ -36,8 +36,8 @@ class PublicSurveysController {
   @Post()
   @Public()
   async answerSurvey(@Body() pushAnswerDto: PushAnswerDto) {
-    const { surveyId, saveNo, answer } = pushAnswerDto;
-    return this.surveyAnswerService.addAnswer(surveyId, saveNo, answer);
+    const { surveyId, saveNo, answer, userInfo } = pushAnswerDto;
+    return this.surveyAnswerService.addAnswer(surveyId, saveNo, answer, userInfo);
   }
 
   @Get(`${RESTFUL_CHOICES}/:surveyId/:questionId`)

--- a/apps/frontend/src/locales/de/translation.json
+++ b/apps/frontend/src/locales/de/translation.json
@@ -530,7 +530,13 @@
       "expectingUserInput": "Hier wird die Antwort des Teilnehmers erwartet, ... "
     },
     "participate": {
-      "saveAnswerSuccess": "Die Antwort wurde gespeichert."
+      "saveAnswerSuccess": "Die Antwort wurde gespeichert.",
+      "enterUserInfo": "Bitte gib deinen Namen und deine E-Mail-Adresse ein.",
+      "preferred_username": "Bevorzugter Name",
+      "given_name": "Vorname",
+      "family_name": "Nachname",
+      "email": "E-Mail",
+      "saveUserInfo": "Weiter"
     },
     "errors": {
       "submitAnswerError": "Die Antwort konnte nicht gespeichert werden.",

--- a/apps/frontend/src/locales/en/translation.json
+++ b/apps/frontend/src/locales/en/translation.json
@@ -528,7 +528,13 @@
       "expectingUserInput": "Expecting the user to answer here, ... "
     },
     "participate": {
-      "saveAnswerSuccess": "Saved the answer."
+      "saveAnswerSuccess": "Saved the answer.",
+      "enterUserInfo": "Please enter your information",
+      "preferred_username": "Preferred name",
+      "given_name": "First name",
+      "family_name": "Last name",
+      "email": "E-mail",
+      "saveUserInfo": "Next"
     },
     "errors": {
       "submitAnswerError": "Not able to submit the answer.",

--- a/apps/frontend/src/pages/Surveys/Participation/EnterUserInformation.tsx
+++ b/apps/frontend/src/pages/Surveys/Participation/EnterUserInformation.tsx
@@ -1,0 +1,116 @@
+/*
+ * LICENSE
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import React from 'react';
+import { z } from 'zod';
+import { useForm } from 'react-hook-form';
+import { useTranslation } from 'react-i18next';
+import UserInfo from '@libs/user/types/jwt/userinfo';
+import { zodResolver } from '@hookform/resolvers/zod';
+import FormField from '@/components/shared/FormField';
+import { Form } from '@/components/ui/Form';
+import { Card } from '@/components/shared/Card';
+import { Button } from '@/components/shared/Button';
+
+interface EnterUserInformationProps {
+  setUserInfo: (userInfo: UserInfo) => void;
+}
+
+const EnterUserInformation = (props: EnterUserInformationProps) => {
+  const { setUserInfo } = props;
+
+  const { t } = useTranslation();
+
+  const formSchema: z.Schema = z.object({
+    preferred_username: z
+      .string({ required_error: 'username.required' })
+      .max(32, { message: 'login.username_too_long' }),
+    given_name: z.string().optional(),
+    family_name: z.string().optional(),
+    email: z.string().optional(),
+  });
+
+  const form = useForm({
+    mode: 'onSubmit',
+    resolver: zodResolver(formSchema),
+    defaultValues: {
+      preferred_username: '',
+      given_name: '',
+      family_name: '',
+      email: '',
+    },
+  });
+
+  return (
+    <Card
+      variant="modal"
+      className="border-2 bg-overlay"
+    >
+      <h4 className="mb-8 flex justify-center text-background">{t('survey.participate.enterUserInfo')}</h4>
+      <Form
+        {...form}
+        data-testid="test-id-login-page-form"
+      >
+        <form
+          onSubmit={form.handleSubmit(() => setUserInfo(form.getValues()))}
+          className="space-y-2"
+          data-testid="test-id-login-page-form"
+        >
+          <FormField
+            form={form}
+            name="preferred_username"
+            value={form.watch('preferred_username')}
+            onChange={(e) => form.setValue('preferred_username', e.target.value)}
+            labelTranslationId="survey.participate.preferred_username"
+          />
+          {!form.getFieldState('preferred_username').error && <p className="flex h-2" />}
+          <FormField
+            form={form}
+            name="given_name"
+            value={form.watch('given_name')}
+            onChange={(e) => form.setValue('given_name', e.target.value)}
+            labelTranslationId="survey.participate.given_name"
+          />
+          {!form.getFieldState('given_name').error && <p className="flex h-2" />}
+          <FormField
+            form={form}
+            name="family_name"
+            value={form.watch('family_name')}
+            onChange={(e) => form.setValue('family_name', e.target.value)}
+            labelTranslationId="survey.participate.family_name"
+          />
+          {!form.getFieldState('family_name').error && <p className="flex h-2" />}
+          <FormField
+            form={form}
+            name="email"
+            value={form.watch('email')}
+            onChange={(e) => form.setValue('email', e.target.value)}
+            labelTranslationId="survey.participate.email"
+          />
+          {!form.getFieldState('email').error && <p className="flex h-2" />}
+
+          <div className="mt-12 flex justify-end">
+            <Button
+              type="submit"
+              variant="btn-collaboration"
+              size="lg"
+            >
+              {t('survey.participate.saveUserInfo')}
+            </Button>
+          </div>
+        </form>
+      </Form>
+    </Card>
+  );
+};
+
+export default EnterUserInformation;

--- a/libs/src/user/types/jwt/userinfo.ts
+++ b/libs/src/user/types/jwt/userinfo.ts
@@ -10,16 +10,11 @@
  * You should have received a copy of the GNU Affero General Public License along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
-import UserInfo from '@libs/user/types/jwt/userinfo';
-
-interface PushAnswerDto {
-  surveyId: string;
-
-  saveNo: number;
-
-  answer: JSON;
-
-  userInfo?: UserInfo;
+interface UserInfo {
+  preferred_username: string;
+  given_name?: string;
+  family_name?: string;
+  email?: string;
 }
 
-export default PushAnswerDto;
+export default UserInfo;


### PR DESCRIPTION
Issue: https://github.com/edulution-io/edulution-ui/issues/496

496:
* when answering on the public participate survey page pass the information of the current user
* when logged in it should take the logged in user as current participant 
* add a modal to retrieve the user information when the user is not logged in