### PR TITLE
Set page title dynamically

### DIFF
--- a/apps/frontend/src/App.tsx
+++ b/apps/frontend/src/App.tsx
@@ -17,6 +17,7 @@ import { WebStorageStateStore } from 'oidc-client-ts';
 import i18n from '@/i18n';
 import eduApi from '@/api/eduApi';
 import useLmnApiStore from '@/store/useLmnApiStore';
+import { HelmetProvider } from 'react-helmet-async';
 import lmnApi from '@/api/lmnApi';
 import useUserStore from '@/store/UserStore/UserStore';
 import Toaster from '@/components/ui/Toaster';
@@ -55,7 +56,9 @@ const App = () => {
   return (
     <AuthProvider {...oidcConfig}>
       <GlobalHooksWrapper>
-        <AppRouter />
+        <HelmetProvider>
+          <AppRouter />
+        </HelmetProvider>
         <Toaster />
       </GlobalHooksWrapper>
     </AuthProvider>

--- a/apps/frontend/src/components/PageTitle.tsx
+++ b/apps/frontend/src/components/PageTitle.tsx
@@ -11,16 +11,25 @@
  */
 
 import React from 'react';
-import PageTitle from '@/components/PageTitle';
-import DockerContainerTable from '../AppConfig/DockerIntegration/DockerContainerTable';
-import LicenseOverview from './LicenseOverview';
+import { Helmet } from 'react-helmet-async';
+import { useTranslation } from 'react-i18next';
 
-const SettingsOverviewPage: React.FC = () => (
-  <>
-    <PageTitle translationId="settings.sidebar" />
-    <LicenseOverview />
-    <DockerContainerTable />
-  </>
-);
+interface PageTitleProps {
+  title?: string;
+  translationId: string;
+}
 
-export default SettingsOverviewPage;
+const PageTitle = ({ title, translationId }: PageTitleProps) => {
+  const { t } = useTranslation();
+
+  return (
+    <Helmet>
+      <title>
+        {title ? `${title} - ` : ''}
+        {t(translationId)} - edulution.io
+      </title>
+    </Helmet>
+  );
+};
+
+export default PageTitle;

--- a/apps/frontend/src/components/framing/EmbeddedIframes.tsx
+++ b/apps/frontend/src/components/framing/EmbeddedIframes.tsx
@@ -14,6 +14,7 @@ import React from 'react';
 import useFrameStore from '@/components/framing/FrameStore';
 import useAppConfigsStore from '@/pages/Settings/AppConfig/appConfigsStore';
 import APP_INTEGRATION_VARIANT from '@libs/appconfig/constants/appIntegrationVariants';
+import PageTitle from '@/components/PageTitle';
 
 const EmbeddedIframes = () => {
   const { appConfigs } = useAppConfigsStore();
@@ -25,13 +26,16 @@ const EmbeddedIframes = () => {
       const isOpen = activeEmbeddedFrame === appConfig.name;
       const url = loadedEmbeddedFrames.includes(appConfig.name) ? appConfig.options.url : undefined;
       return (
-        <iframe
-          key={appConfig.name}
-          title={appConfig.name}
-          className={`absolute inset-y-0 left-0 ml-0 mr-14 w-full md:w-[calc(100%-var(--sidebar-width))] ${isOpen ? 'block' : 'hidden'}`}
-          height="100%"
-          src={url}
-        />
+        <>
+          <PageTitle translationId={`${appConfig.name}.sidebar`} />
+          <iframe
+            key={appConfig.name}
+            title={appConfig.name}
+            className={`absolute inset-y-0 left-0 ml-0 mr-14 w-full md:w-[calc(100%-var(--sidebar-width))] ${isOpen ? 'block' : 'hidden'}`}
+            height="100%"
+            src={url}
+          />
+        </>
       );
     });
 };

--- a/apps/frontend/src/components/framing/Native/NativeIframeLayout.tsx
+++ b/apps/frontend/src/components/framing/Native/NativeIframeLayout.tsx
@@ -18,6 +18,7 @@ import { toast } from 'sonner';
 import { useTranslation } from 'react-i18next';
 import findAppConfigByName from '@libs/common/utils/findAppConfigByName';
 import type TApps from '@libs/appconfig/types/appsType';
+import PageTitle from '@/components/PageTitle';
 
 interface NativeIframeLayoutProps {
   scriptOnStartUp?: string;
@@ -80,14 +81,17 @@ const NativeIframeLayout: React.FC<NativeIframeLayoutProps> = ({ scriptOnStartUp
   }
 
   return (
-    <iframe
-      ref={iframeRef}
-      title={appName}
-      className="absolute inset-y-0 left-0 ml-0 mr-14 w-full md:w-[calc(100%-var(--sidebar-width))]"
-      height="100%"
-      src={loadedEmbeddedFrames.includes(currentAppConfig.name) ? initialUrlRef.current : undefined}
-      style={getStyle()}
-    />
+    <>
+      <PageTitle translationId={`${appName}.sidebar`} />
+      <iframe
+        ref={iframeRef}
+        title={appName}
+        className="absolute inset-y-0 left-0 ml-0 mr-14 w-full md:w-[calc(100%-var(--sidebar-width))]"
+        height="100%"
+        src={loadedEmbeddedFrames.includes(currentAppConfig.name) ? initialUrlRef.current : undefined}
+        style={getStyle()}
+      />
+    </>
   );
 };
 

--- a/apps/frontend/src/components/layout/NativeAppHeader.tsx
+++ b/apps/frontend/src/components/layout/NativeAppHeader.tsx
@@ -13,6 +13,7 @@
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { NATIVE_APP_HEADER_ID } from '@libs/common/constants/pageElementIds';
+import PageTitle from '@/components/PageTitle';
 
 interface NativeAppHeaderProps {
   title: string;
@@ -27,6 +28,7 @@ const NativeAppHeader = ({ title, iconSrc, description }: NativeAppHeaderProps) 
       className="mr-2 flex min-h-[6.25rem] text-background xl:max-h-[6.25rem]"
       id={NATIVE_APP_HEADER_ID}
     >
+      <PageTitle translationId={title} />
       <img
         src={iconSrc}
         alt={`${title} ${t('common.icon')}`}

--- a/apps/frontend/src/components/shared/MenuBar.tsx
+++ b/apps/frontend/src/components/shared/MenuBar.tsx
@@ -20,8 +20,11 @@ import { useOnClickOutside, useToggle } from 'usehooks-ts';
 import useMedia from '@/hooks/useMedia';
 import { getFromPathName } from '@libs/common/utils';
 import APPS from '@libs/appconfig/constants/apps';
+import PageTitle from '@/components/PageTitle';
+import { useTranslation } from 'react-i18next';
 
 const MenuBar: React.FC = () => {
+  const { t } = useTranslation();
   const [isOpen, toggle] = useToggle(false);
   const menubarRef = useRef<HTMLDivElement>(null);
   const { pathname } = useLocation();
@@ -73,6 +76,12 @@ const MenuBar: React.FC = () => {
       <MenubarMenu>
         {menuBarEntries.menuItems.map((item) => (
           <React.Fragment key={item.label}>
+            {isSelected === item.id && (
+              <PageTitle
+                title={t(`${menuBarEntries.appName}.sidebar`)}
+                translationId={item.label}
+              />
+            )}
             <MenubarTrigger
               className={cn(
                 'flex w-full cursor-pointer items-center gap-3 py-1 pl-3 pr-10 transition-colors',

--- a/apps/frontend/src/components/ui/Header.tsx
+++ b/apps/frontend/src/components/ui/Header.tsx
@@ -18,6 +18,7 @@ import { useTranslation } from 'react-i18next';
 import useMedia from '@/hooks/useMedia';
 import useUserStore from '@/store/UserStore/UserStore';
 import { BLANK_LAYOUT_HEADER_ID } from '@libs/common/constants/pageElementIds';
+import PageTitle from '@/components/PageTitle';
 
 interface HeaderProps {
   hideHeadingText?: boolean;
@@ -47,6 +48,7 @@ const Header: React.FC<HeaderProps> = ({ hideHeadingText = false }: HeaderProps)
       id={BLANK_LAYOUT_HEADER_ID}
       className="ml-2 flex items-center pb-1 md:mb-3 md:ml-7"
     >
+      <PageTitle translationId="dashboard.pageTitle" />
       <div className={`rounded-b-[8px] ${isMobileView ? 'mt-3 w-[150px]' : 'mt-0 w-[250px] bg-white'}`}>
         <Link to="/">
           <img

--- a/apps/frontend/src/components/ui/Sidebar/SidebarMenuItems/SidebarItem.tsx
+++ b/apps/frontend/src/components/ui/Sidebar/SidebarMenuItems/SidebarItem.tsx
@@ -17,6 +17,7 @@ import { SIDEBAR_ICON_WIDTH, SIDEBAR_TRANSLATE_AMOUNT } from '@libs/ui/constants
 import { SidebarMenuItemProps } from '@libs/ui/types/sidebar';
 import { getRootPathName } from '@libs/common/utils';
 import SidebarItemNotification from '@/components/ui/Sidebar/SidebarMenuItems/SidebarItemNotification';
+import PageTitle from '@/components/PageTitle';
 
 const SidebarItem: React.FC<SidebarMenuItemProps> = ({ menuItem, isDesktop, translate }) => {
   const { title, icon, color, link, notificationCounter } = menuItem;
@@ -34,15 +35,18 @@ const SidebarItem: React.FC<SidebarMenuItemProps> = ({ menuItem, isDesktop, tran
     setIsInView(rect.bottom < window.innerHeight - SIDEBAR_TRANSLATE_AMOUNT);
   }, [translate, size]);
 
+  const isCurrentlySelectedItem = rootPathName === menuItem.link && pathname !== '/';
+
   return (
     <div
       key={title}
       className="relative"
       ref={buttonRef}
     >
+      {isCurrentlySelectedItem && <PageTitle translationId={title} />}
       <NavLink
         to={link}
-        className={`group relative z-[99] flex cursor-pointer items-center justify-end gap-4 px-4 py-2 md:block md:px-2 ${rootPathName === menuItem.link && pathname !== '/' ? menuItem.color : ''}`}
+        className={`group relative z-[99] flex cursor-pointer items-center justify-end gap-4 px-4 py-2 md:block md:px-2 ${isCurrentlySelectedItem ? menuItem.color : ''}`}
       >
         <p className="md:hidden">{title}</p>
         <>

--- a/apps/frontend/src/locales/de/translation.json
+++ b/apps/frontend/src/locales/de/translation.json
@@ -102,6 +102,7 @@
     "sidebar": "Eingebettet"
   },
   "dashboard": {
+    "pageTitle": "Dashboard",
     "mobileAccess": {
       "title": "Mobiler Datenzugriff",
       "manual": "Anleitung",
@@ -509,6 +510,7 @@
     "attendees": "Teilnehmer",
     "newTitle": "Neue Umfrage",
     "filterPlaceHolderText": "Suche nach Umfragename",
+    "publicSurvey": "Öffentliche Umfrage",
     "invitedAttendees": "Eingeladen",
     "isPublic": "Sichtbarkeit",
     "isPublicTrue": "Öffentlich",
@@ -911,6 +913,7 @@
   "students": "Schüler",
   "user": "Benutzer",
   "login": {
+    "pageTitle": "Login",
     "username_too_long": "Benutzername zu lang",
     "password_too_long": "Passwort zu lang",
     "forgot_password": "Passwort vergessen?",

--- a/apps/frontend/src/locales/en/translation.json
+++ b/apps/frontend/src/locales/en/translation.json
@@ -102,6 +102,7 @@
     "sidebar": "Embedded"
   },
   "dashboard": {
+    "pageTitle": "Dashboard",
     "mobileAccess": {
       "title": "Mobile File Access",
       "manual": "Setup",
@@ -507,6 +508,7 @@
     "attendees": "Attendees",
     "filterPlaceHolderText": "Search for surveyname",
     "invitedAttendees": "Invited",
+    "publicSurvey": "Public survey",
     "isPublic": "Publicly displayed (?)",
     "isPublicTrue": "Public",
     "isPublicFalse": "Private",
@@ -909,6 +911,7 @@
   "students": "Students",
   "user": "User",
   "login": {
+    "pageTitle": "Login",
     "username_too_long": "Username to long",
     "password_too_long": "Password to long",
     "forgot_password": "Forgot password?",

--- a/apps/frontend/src/pages/ConferencePage/ConferencePage.tsx
+++ b/apps/frontend/src/pages/ConferencePage/ConferencePage.tsx
@@ -35,7 +35,7 @@ const ConferencePage: React.FC = () => {
   return (
     <div>
       <NativeAppHeader
-        title={t('conferences.title')}
+        title={t('conferences.sidebar')}
         description={t('conferences.description')}
         iconSrc={ConferencesIcon}
       />

--- a/apps/frontend/src/pages/FileSharing/FilePreview/FullScreenFileViewer.tsx
+++ b/apps/frontend/src/pages/FileSharing/FilePreview/FullScreenFileViewer.tsx
@@ -17,6 +17,7 @@ import { useTranslation } from 'react-i18next';
 import FileRenderer from '@/pages/FileSharing/FilePreview/FileRenderer';
 import useFileEditorStore from '@/pages/FileSharing/FilePreview/OnlyOffice/useFileEditorStore';
 import LoadingIndicatorDialog from '@/components/ui/Loading/LoadingIndicatorDialog';
+import PageTitle from '@/components/PageTitle';
 
 const FullScreenFileViewer = () => {
   const { t } = useTranslation();
@@ -24,6 +25,7 @@ const FullScreenFileViewer = () => {
   const {
     filesToOpenInNewTab,
     fetchDownloadLinks,
+    currentlyEditingFile,
     setCurrentlyEditingFile,
     downloadLinkURL,
     isEditorLoading,
@@ -56,6 +58,10 @@ const FullScreenFileViewer = () => {
 
   return (
     <div className="h-screen w-screen">
+      <PageTitle
+        title={currentlyEditingFile?.basename}
+        translationId="filesharing.sidebar"
+      />
       <FileRenderer
         editMode
         isOpenedInNewTab

--- a/apps/frontend/src/pages/ForwardingPage/ForwardingPage.tsx
+++ b/apps/frontend/src/pages/ForwardingPage/ForwardingPage.tsx
@@ -19,10 +19,14 @@ import useAppConfigsStore from '@/pages/Settings/AppConfig/appConfigsStore';
 import { toast } from 'sonner';
 import { getFromPathName } from '@libs/common/utils';
 import findAppConfigByName from '@libs/common/utils/findAppConfigByName';
+import PageTitle from '@/components/PageTitle';
+import getDisplayName from '@/utils/getDisplayName';
+import useLanguage from '@/hooks/useLanguage';
 
 const ForwardingPage: React.FC = () => {
   const { t } = useTranslation();
   const { pathname } = useLocation();
+  const { language } = useLanguage();
 
   const [isForwarding, setIsForwarding] = useState(false);
   const [showIsForwarding, setShowIsForwarding] = useState(false);
@@ -51,8 +55,12 @@ const ForwardingPage: React.FC = () => {
 
   const currentAppConfig = findAppConfigByName(appConfigs, rootPathName);
 
+  if (!currentAppConfig) return null;
+  const pageTitle = getDisplayName(currentAppConfig, language);
+
   return (
     <div className="grid h-[80%] items-center justify-center">
+      <PageTitle translationId={pageTitle} />
       <h2 className="text-center text-background">{t('forwardingpage.action')}</h2>
       <div className="mt-20 flex justify-center">
         <img
@@ -71,8 +79,8 @@ const ForwardingPage: React.FC = () => {
         >
           <img
             className="m-10 w-[200px] md:m-[20] md:w-[200px]"
-            src={currentAppConfig?.icon}
-            alt={currentAppConfig?.name}
+            src={currentAppConfig.icon}
+            alt={currentAppConfig.name}
           />
         </Button>
       </div>

--- a/apps/frontend/src/pages/LoginPage/LoginPage.tsx
+++ b/apps/frontend/src/pages/LoginPage/LoginPage.tsx
@@ -26,6 +26,7 @@ import useUserStore from '@/store/UserStore/UserStore';
 import UserDto from '@libs/user/types/user.dto';
 import processLdapGroups from '@libs/user/utils/processLdapGroups';
 import OtpInput from '@/components/shared/OtpInput';
+import PageTitle from '@/components/PageTitle';
 import getLoginFormSchema from './getLoginFormSchema';
 
 type LocationState = {
@@ -162,70 +163,73 @@ const LoginPage: React.FC = () => {
   );
 
   return (
-    <Card
-      variant="modal"
-      className="bg-background"
-    >
-      <img
-        src={DesktopLogo}
-        alt="edulution"
-        className="mx-auto w-64"
-      />
-      <Form
-        {...form}
-        data-testid="test-id-login-page-form"
+    <>
+      <PageTitle translationId="login.pageTitle" />
+      <Card
+        variant="modal"
+        className="bg-background"
       >
-        <form
-          onSubmit={form.handleSubmit(isEnterTotpVisible ? onSubmit : handleCheckMfaStatus)}
-          className="space-y-4"
+        <img
+          src={DesktopLogo}
+          alt="edulution"
+          className="mx-auto w-64"
+        />
+        <Form
+          {...form}
           data-testid="test-id-login-page-form"
         >
-          {isEnterTotpVisible ? (
-            <>
-              <div className="mt-3 text-center font-bold">{t('login.enterMultiFactorCode')}</div>
-              <OtpInput
-                totp={totp}
-                setTotp={setTotp}
-                onComplete={form.handleSubmit(onSubmit)}
-              />
-              {form.getFieldState('password').error?.message && (
-                <p>
-                  <span>{t(form.getFieldState('password').error?.message || '')}</span>
-                </p>
-              )}
-            </>
-          ) : (
-            <>
-              {renderFormField('username', t('common.username'), 'text', true)}
-              {renderFormField('password', t('common.password'), 'password')}
-            </>
-          )}
-          {!form.getFieldState('password').error && <p className="flex h-2" />}
-          {isEnterTotpVisible ? (
-            <Button
-              className="mx-auto w-full justify-center text-foreground shadow-xl hover:bg-ciGrey/10"
-              type="button"
-              variant="btn-outline"
-              size="lg"
-              disabled={isLoading || totpIsLoading}
-              onClick={() => setIsEnterTotpVisible(false)}
-            >
-              {t('common.cancel')}
-            </Button>
-          ) : null}
-          <Button
-            className="mx-auto w-full justify-center text-background shadow-xl"
-            type="submit"
-            variant="btn-security"
-            size="lg"
-            data-testid="test-id-login-page-submit-button"
-            disabled={isLoading || totpIsLoading}
+          <form
+            onSubmit={form.handleSubmit(isEnterTotpVisible ? onSubmit : handleCheckMfaStatus)}
+            className="space-y-4"
+            data-testid="test-id-login-page-form"
           >
-            {totpIsLoading || isLoading ? t('common.loading') : t('common.login')}
-          </Button>
-        </form>
-      </Form>
-    </Card>
+            {isEnterTotpVisible ? (
+              <>
+                <div className="mt-3 text-center font-bold">{t('login.enterMultiFactorCode')}</div>
+                <OtpInput
+                  totp={totp}
+                  setTotp={setTotp}
+                  onComplete={form.handleSubmit(onSubmit)}
+                />
+                {form.getFieldState('password').error?.message && (
+                  <p>
+                    <span>{t(form.getFieldState('password').error?.message || '')}</span>
+                  </p>
+                )}
+              </>
+            ) : (
+              <>
+                {renderFormField('username', t('common.username'), 'text', true)}
+                {renderFormField('password', t('common.password'), 'password')}
+              </>
+            )}
+            {!form.getFieldState('password').error && <p className="flex h-2" />}
+            {isEnterTotpVisible ? (
+              <Button
+                className="mx-auto w-full justify-center text-foreground shadow-xl hover:bg-ciGrey/10"
+                type="button"
+                variant="btn-outline"
+                size="lg"
+                disabled={isLoading || totpIsLoading}
+                onClick={() => setIsEnterTotpVisible(false)}
+              >
+                {t('common.cancel')}
+              </Button>
+            ) : null}
+            <Button
+              className="mx-auto w-full justify-center text-background shadow-xl"
+              type="submit"
+              variant="btn-security"
+              size="lg"
+              data-testid="test-id-login-page-submit-button"
+              disabled={isLoading || totpIsLoading}
+            >
+              {totpIsLoading || isLoading ? t('common.loading') : t('common.login')}
+            </Button>
+          </form>
+        </Form>
+      </Card>
+    </>
   );
 };
 

--- a/apps/frontend/src/pages/Whiteboard/Whiteboard.tsx
+++ b/apps/frontend/src/pages/Whiteboard/Whiteboard.tsx
@@ -16,6 +16,7 @@ import cn from '@libs/common/utils/className';
 import useFrameStore from '@/components/framing/FrameStore';
 import APPS from '@libs/appconfig/constants/apps';
 import useLanguage from '@/hooks/useLanguage';
+import PageTitle from '@/components/PageTitle';
 
 const Whiteboard = () => {
   const { activeEmbeddedFrame } = useFrameStore();
@@ -30,6 +31,7 @@ const Whiteboard = () => {
         getStyle(),
       )}
     >
+      <PageTitle translationId="whiteboard.sidebar" />
       <div className="h-full w-full flex-grow">
         <Excalidraw
           theme={THEME.DARK}

--- a/apps/frontend/src/router/routes/PublicRoutes.tsx
+++ b/apps/frontend/src/router/routes/PublicRoutes.tsx
@@ -17,6 +17,7 @@ import SurveyParticipationPage from '@/pages/Surveys/Participation/SurveyPartici
 import BlankLayout from '@/components/layout/BlankLayout';
 import { CONFERENCES_PUBLIC_EDU_API_ENDPOINT } from '@libs/conferences/constants/apiEndpoints';
 import PublicConferencePage from '@/pages/ConferencePage/PublicConference/PublicConferencePage';
+import PageTitle from '@/components/PageTitle';
 
 const getPublicRoutes = () => [
   <Route
@@ -25,7 +26,12 @@ const getPublicRoutes = () => [
   >
     <Route
       path={`${CONFERENCES_PUBLIC_EDU_API_ENDPOINT}/:meetingId`}
-      element={<PublicConferencePage />}
+      element={
+        <>
+          <PageTitle translationId="conferences.publicConference" />
+          <PublicConferencePage />
+        </>
+      }
     />
   </Route>,
   <Route
@@ -34,7 +40,12 @@ const getPublicRoutes = () => [
   >
     <Route
       path={`${PUBLIC_SURVEYS}/:surveyId`}
-      element={<SurveyParticipationPage isPublic />}
+      element={
+        <>
+          <PageTitle translationId="survey.publicSurvey" />
+          <SurveyParticipationPage isPublic />
+        </>
+      }
     />
   </Route>,
 ];

--- a/package-lock.json
+++ b/package-lock.json
@@ -94,6 +94,7 @@
         "react-dom": "^18.2.0",
         "react-dropzone": "^14.2.3",
         "react-file-icon": "^1.4.0",
+        "react-helmet-async": "^2.0.5",
         "react-hook-form": "^7.51.1",
         "react-i18next": "^14.0.3",
         "react-icons": "^5.0.1",
@@ -18043,6 +18044,14 @@
         "node": ">=10.13.0"
       }
     },
+    "node_modules/invariant": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
+      "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
+      "dependencies": {
+        "loose-envify": "^1.0.0"
+      }
+    },
     "node_modules/ioredis": {
       "version": "5.6.0",
       "resolved": "https://registry.npmjs.org/ioredis/-/ioredis-5.6.0.tgz",
@@ -24520,6 +24529,19 @@
         "react-dom": "^19.0.0 || ^18.0.0 || ^17.0.0 || ^16.2.0"
       }
     },
+    "node_modules/react-helmet-async": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/react-helmet-async/-/react-helmet-async-2.0.5.tgz",
+      "integrity": "sha512-rYUYHeus+i27MvFE+Jaa4WsyBKGkL6qVgbJvSBoX8mbsWoABJXdEO0bZyi0F6i+4f0NuIb8AvqPMj3iXFHkMwg==",
+      "dependencies": {
+        "invariant": "^2.2.4",
+        "react-fast-compare": "^3.2.2",
+        "shallowequal": "^1.1.0"
+      },
+      "peerDependencies": {
+        "react": "^16.6.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
     "node_modules/react-hook-form": {
       "version": "7.54.2",
       "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.54.2.tgz",
@@ -26318,6 +26340,11 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/shallowequal": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/shallowequal/-/shallowequal-1.1.0.tgz",
+      "integrity": "sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ=="
     },
     "node_modules/sharp": {
       "version": "0.33.5",

--- a/package.json
+++ b/package.json
@@ -117,6 +117,7 @@
     "react-dom": "^18.2.0",
     "react-dropzone": "^14.2.3",
     "react-file-icon": "^1.4.0",
+    "react-helmet-async": "^2.0.5",
     "react-hook-form": "^7.51.1",
     "react-i18next": "^14.0.3",
     "react-icons": "^5.0.1",


### PR DESCRIPTION
By default we will set the page title in the Sidebar. This does not work in all circumstances, e.g. nested navigation, missing sidebar, subpages etc. The page title is set on these pages manually.

Page title was set and checked for:
- Dashboard
- Native Apps with NativeAppHeader
- All EmbeddedIframes (Whiteboard, Mail, Linuxmuster, + custome ones)
- All UserSettings pages
- All Settings (AppConfig) pages
	- Including App-Store + SettingsOverviewPage
- All Subpages (MenuBarEntries)
- FileSharingPreview (EmptyLayout)
- BlankLayout (Login, ForwardingPage, PublicSurveyPage, PublicConferencePage)