### PR TITLE
785 - Survey - backend limiter - check the visualization of the survey result table when using backend limiter

### DIFF
--- a/apps/api/src/surveys/survey-answer.service.ts
+++ b/apps/api/src/surveys/survey-answer.service.ts
@@ -73,7 +73,7 @@ class SurveyAnswersService {
 
     const filteredChoices = await Promise.all(
       possibleChoices.map(async (choice) => {
-        const isVisible = (await this.countChoiceSelections(surveyId, questionName, choice.name)) < choice.limit;
+        const isVisible = (await this.countChoiceSelections(surveyId, questionName, choice.title)) < choice.limit;
         return isVisible ? choice : null;
       }),
     );

--- a/apps/frontend/src/pages/Surveys/Editor/dialog/backend-limiter/ChoicesByUrl.tsx
+++ b/apps/frontend/src/pages/Surveys/Editor/dialog/backend-limiter/ChoicesByUrl.tsx
@@ -104,6 +104,8 @@ const ChoicesByUrl = (props: ChoicesByUrlProps) => {
         correspondingQuestion.choices = null;
         correspondingQuestion.choicesByUrl = {
           url: `${EDU_API_URL}/${SURVEY_CHOICES}/${TEMPORAL_SURVEY_ID_STRING}/${selectedQuestion.name}`,
+          valueName: 'title',
+          titleName: 'title',
         };
         correspondingQuestion.hideIfChoicesEmpty = true;
       }

--- a/libs/src/survey/types/TSurveyElement.ts
+++ b/libs/src/survey/types/TSurveyElement.ts
@@ -17,7 +17,11 @@ interface SurveyElement {
   description?: string;
   choicesOrder?: string;
   choices: string[] | null;
-  choicesByUrl: { url: string } | null;
+  choicesByUrl: {
+    url: string;
+    valueName?: string;
+    titleName?: string;
+  } | null;
   hideIfChoicesEmpty?: boolean;
   showOtherItem: boolean | null;
   showNoneItem?: boolean;


### PR DESCRIPTION
Issue: https://github.com/edulution-io/edulution-ui/issues/785

785:
 * use the choices.title as valueName and titleName because surveyParticipationModel.getData() only returns the name (id) or the title (value) i enforce the title as answer

We would have to update the Surveys and Templates by adding following two lines:
![image](https://github.com/user-attachments/assets/68f9a143-01ae-4a67-a6bc-87b38b48cc46)
