### PR TITLE
Fix sidebar in mobile view

### DIFF
--- a/apps/frontend/src/components/ui/Sidebar/MobileSidebar.tsx
+++ b/apps/frontend/src/components/ui/Sidebar/MobileSidebar.tsx
@@ -34,6 +34,8 @@ const MobileSidebar: React.FC<SidebarProps> = ({ sidebarItems }) => {
 
   useOnClickOutside(sidebarRef, handleClickOutside);
 
+  const sidebarHeightWithoutSpecialButtons = 'h-[calc(100%-112px)]';
+
   return (
     <>
       <MobileMenuButton ref={buttonRef} />
@@ -46,7 +48,7 @@ const MobileSidebar: React.FC<SidebarProps> = ({ sidebarItems }) => {
           className="fixed right-0 h-full min-w-[260px] border-l-[1px] border-muted bg-black md:bg-none"
         >
           <div className="relative right-0 top-0 h-14 bg-black pr-4 pt-4" />
-          <div className="h-[calc(100%-56px)] overflow-auto">
+          <div className={`${sidebarHeightWithoutSpecialButtons} overflow-auto`}>
             <HomeButton />
             {sidebarItems.map((item) => (
               <MobileSidebarItem

--- a/apps/frontend/src/components/ui/Sidebar/SidebarMenuItems/UserMenuButton.tsx
+++ b/apps/frontend/src/components/ui/Sidebar/SidebarMenuItems/UserMenuButton.tsx
@@ -37,9 +37,9 @@ const UserMenuButton: React.FC = () => {
   return (
     <div
       key="usermenu"
-      className="fixed bottom-0 right-0 bg-black"
+      className="fixed bottom-0 right-0 min-w-[260px] bg-black md:min-w-0"
     >
-      <div className="flex max-h-14 cursor-pointer items-center justify-start gap-4 px-4 py-2 md:block md:px-2">
+      <div className="flex max-h-14 cursor-pointer items-center justify-end gap-4 px-4 py-2 md:block md:px-2">
         <DropdownMenu
           menuContentClassName="z-[600]"
           trigger={


### PR DESCRIPTION
I extracted the classname to give it an explaining variable name.
Also fixed the issue:
![grafik](https://github.com/user-attachments/assets/2a4d447e-897f-4eb1-bcb3-7f5a3dc11031)

Tested in FF and Chrome, works also for long app names:
![grafik](https://github.com/user-attachments/assets/3c4fc6c6-bbba-4976-a466-a494d89bcfdb)
