### PR TITLE
DirectoryBreadcrumb has wrong segment encoding 

### DIFF
--- a/apps/frontend/src/pages/FileSharing/Table/DirectoryBreadcrumb.tsx
+++ b/apps/frontend/src/pages/FileSharing/Table/DirectoryBreadcrumb.tsx
@@ -48,7 +48,13 @@ const DirectoryBreadcrumb: React.FC<DirectoryBreadcrumbProps> = ({
 
   const segments = path
     .split('/')
-    .map((segment) => segment.replace(/%20/g, ' '))
+    .map((segment) => {
+      try {
+        return decodeURIComponent(segment);
+      } catch {
+        return segment;
+      }
+    })
     .filter(Boolean);
 
   const clearSegments = segments.filter((segment) => hiddenSegments?.includes(segment) !== true);


### PR DESCRIPTION
<img width="905" alt="image" src="https://github.com/user-attachments/assets/9ac80e82-a3b9-4926-8956-d9090252da4c" />


=> 

<img width="403" alt="image" src="https://github.com/user-attachments/assets/adb51ffe-2d49-4e93-9fcc-c71571d16910" />
