### PR TITLE
Fix tooltips in class management

### DIFF
--- a/apps/frontend/src/components/shared/ActionTooltip.tsx
+++ b/apps/frontend/src/components/shared/ActionTooltip.tsx
@@ -49,7 +49,7 @@ const ActionTooltip: React.FC<ActionTooltipProps> = ({
         </div>
       </TooltipTrigger>
       <TooltipContent
-        className={cn('rounded-lg bg-accent p-2', className)}
+        className={cn('rounded-lg bg-accent p-2 shadow-xl', className)}
         side={openOnSide}
         align="center"
       >

--- a/apps/frontend/src/pages/ClassManagement/LessonPage/QuickAccess/GroupCard.tsx
+++ b/apps/frontend/src/pages/ClassManagement/LessonPage/QuickAccess/GroupCard.tsx
@@ -65,6 +65,8 @@ const GroupCard = ({ icon, type, group }: GroupCardProps) => {
           <TooltipProvider>
             <ActionTooltip
               tooltipText={title}
+              openOnSide="bottom"
+              className="bg-muted"
               trigger={
                 <p className="overflow-hidden text-ellipsis text-nowrap text-lg font-bold">
                   {removeSchoolPrefix(title, user?.school)}

--- a/apps/frontend/src/pages/ClassManagement/components/GroupList/GroupListCard.tsx
+++ b/apps/frontend/src/pages/ClassManagement/components/GroupList/GroupListCard.tsx
@@ -15,8 +15,6 @@ import React, { useEffect, useState } from 'react';
 import { Card, CardContent } from '@/components/shared/Card';
 import cn from '@libs/common/utils/className';
 import Checkbox from '@/components/ui/Checkbox';
-import { TooltipProvider } from '@/components/ui/Tooltip';
-import ActionTooltip from '@/components/shared/ActionTooltip';
 import { MdLock } from 'react-icons/md';
 import UserGroups from '@libs/groups/types/userGroups.enum';
 import getUserRegex from '@libs/lmnApi/constants/userRegex';
@@ -152,16 +150,9 @@ const GroupListCard: React.FC<GroupListCardProps> = ({ group, type, icon, isEnro
                 ) : (
                   titleIcon
                 )}
-                <TooltipProvider>
-                  <ActionTooltip
-                    tooltipText={displayName || commonName}
-                    trigger={
-                      <div className="ml-2 overflow-hidden whitespace-nowrap text-nowrap text-lg font-bold">
-                        {displayName || removeSchoolPrefix(commonName, user.school)}
-                      </div>
-                    }
-                  />
-                </TooltipProvider>
+                <div className="ml-2 overflow-hidden whitespace-nowrap text-nowrap text-lg font-bold">
+                  {displayName || removeSchoolPrefix(commonName, user.school)}
+                </div>
               </div>
               <div className="ml-3 flex h-10 flex-row items-center">
                 {cardContentIcon}


### PR DESCRIPTION
Before the tooltip was cut off due to the new design where the overflow is hidden. After changing the tooltip position I also changed the background and added a general shadow.
Before:
![grafik](https://github.com/user-attachments/assets/0d341bc7-11af-464e-b5a9-7d8944efd700)

After:
![grafik](https://github.com/user-attachments/assets/212f914c-cdf3-4217-bda4-b4850eee2425)

In the GroupListCard I removed the tooltip because it was not useful anymore since long names would still be cut off due to the overflow: hidden. The full name can be seen by opening the dialog.