### PR TITLE
824 File Manager: Fix docked preview is above dialog

### DIFF
--- a/apps/frontend/src/components/structure/framing/ResizableWindow/ResizableWindow.tsx
+++ b/apps/frontend/src/components/structure/framing/ResizableWindow/ResizableWindow.tsx
@@ -210,7 +210,7 @@ const ResizableWindow: React.FC<ResizableWindowProps> = ({
       disableDragging={disableDragging}
       enableResizing={!isMaximized && !isCurrentlySticky}
       style={{
-        zIndex: zIndex + 500,
+        zIndex: zIndex + (isCurrentlySticky ? 30 : 500),
       }}
     >
       {!hasCurrentFramedWindowHighestZIndex && !isMinimized && (


### PR DESCRIPTION
Currently this fix would be the easiest. If the window is docked, it's always behind the dialogs.
If the modal is undocked it will always be in front. You will first have to minimize it since the dialogs don't work like the resizable windows.

After:

https://github.com/user-attachments/assets/62c1aeb5-9bcf-4065-beaf-adb9ed23c684



