### PR TITLE
753 - Survey visualization: Wrong font color

### DIFF
--- a/apps/frontend/src/pages/Surveys/Tables/components/ResultVisualization.tsx
+++ b/apps/frontend/src/pages/Surveys/Tables/components/ResultVisualization.tsx
@@ -16,6 +16,7 @@ import { VisualizationPanel } from 'survey-analytics';
 import 'survey-analytics/survey.analytics.min.css';
 import TSurveyFormula from '@libs/survey/types/TSurveyFormula';
 import useLanguage from '@/hooks/useLanguage';
+import '../../theme/custom.visualizer.css';
 
 const visuPanelOptions = {
   haveCommercialLicense: true,

--- a/apps/frontend/src/pages/Surveys/theme/custom.visualizer.css
+++ b/apps/frontend/src/pages/Surveys/theme/custom.visualizer.css
@@ -1,0 +1,4 @@
+.sa-visualizer__content {
+  color: var(--foreground);
+  color: var(--foreground);
+}


### PR DESCRIPTION
Issue: https://github.com/edulution-io/edulution-ui/issues/753

753:
* enforce black color inside of the visualization (only text outside of tables)

IMAGE:
![image](https://github.com/user-attachments/assets/163f4e3b-dacf-4264-b41c-808fb83defd3)
