### PR TITLE
672 Add default landing page

### DIFF
--- a/apps/api/src/appconfig/initializeCollection.ts
+++ b/apps/api/src/appconfig/initializeCollection.ts
@@ -10,7 +10,7 @@
  * You should have received a copy of the GNU Affero General Public License along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
-import { Model, Connection } from 'mongoose';
+import { Connection, Model } from 'mongoose';
 import defaultAppConfig from '@libs/appconfig/constants/defaultAppConfig';
 import { AppConfig } from './appconfig.schema';
 

--- a/apps/api/src/bulletin-category/bulletin-category.module.ts
+++ b/apps/api/src/bulletin-category/bulletin-category.module.ts
@@ -16,7 +16,6 @@ import BulletinCategoryController from './bulletin-category.controller';
 import BulletinCategoryService from './bulletin-category.service';
 import { BulletinCategory, BulletinCategorySchema } from './bulletin-category.schema';
 import { Bulletin, BulletinSchema } from '../bulletinboard/bulletin.schema';
-import MigrationService from '../migration/migration.service';
 
 @Module({
   imports: [
@@ -24,7 +23,7 @@ import MigrationService from '../migration/migration.service';
     MongooseModule.forFeature([{ name: BulletinCategory.name, schema: BulletinCategorySchema }]),
   ],
   controllers: [BulletinCategoryController],
-  providers: [BulletinCategoryService, MigrationService],
+  providers: [BulletinCategoryService],
   exports: [BulletinCategoryService],
 })
 export default class BulletinCategoryModule {}

--- a/apps/api/src/global-settings/global-settings.controller.spec.ts
+++ b/apps/api/src/global-settings/global-settings.controller.spec.ts
@@ -16,9 +16,11 @@ import type { UpdateWriteOpResult } from 'mongoose';
 import type GlobalSettingsDto from '@libs/global-settings/types/globalSettings.dto';
 import { GLOBAL_SETTINGS_PROJECTION_PARAM_AUTH } from '@libs/global-settings/constants/globalSettingsApiEndpoints';
 import defaultValues from '@libs/global-settings/constants/defaultValues';
+import { CACHE_MANAGER } from '@nestjs/cache-manager';
 import GlobalSettingsController from './global-settings.controller';
 import GlobalSettingsService from './global-settings.service';
 import AppConfigGuard from '../appconfig/appconfig.guard';
+import cacheManagerMock from '../common/mocks/cacheManagerMock';
 
 const mockedGlobalSettingsDto: GlobalSettingsDto = defaultValues;
 
@@ -52,6 +54,10 @@ describe('GlobalSettingsController', () => {
             getGlobalSettings: jest.fn(),
             setGlobalSettings: jest.fn(),
           },
+        },
+        {
+          provide: CACHE_MANAGER,
+          useValue: cacheManagerMock,
         },
       ],
     })

--- a/apps/api/src/global-settings/global-settings.controller.spec.ts
+++ b/apps/api/src/global-settings/global-settings.controller.spec.ts
@@ -15,10 +15,10 @@ import { Test, TestingModule } from '@nestjs/testing';
 import type { UpdateWriteOpResult } from 'mongoose';
 import type GlobalSettingsDto from '@libs/global-settings/types/globalSettings.dto';
 import { GLOBAL_SETTINGS_PROJECTION_PARAM_AUTH } from '@libs/global-settings/constants/globalSettingsApiEndpoints';
+import defaultValues from '@libs/global-settings/constants/defaultValues';
 import GlobalSettingsController from './global-settings.controller';
 import GlobalSettingsService from './global-settings.service';
 import AppConfigGuard from '../appconfig/appconfig.guard';
-import defaultValues from '@libs/global-settings/constants/defaultValues';
 
 const mockedGlobalSettingsDto: GlobalSettingsDto = defaultValues;
 

--- a/apps/api/src/global-settings/global-settings.controller.spec.ts
+++ b/apps/api/src/global-settings/global-settings.controller.spec.ts
@@ -18,10 +18,9 @@ import { GLOBAL_SETTINGS_PROJECTION_PARAM_AUTH } from '@libs/global-settings/con
 import GlobalSettingsController from './global-settings.controller';
 import GlobalSettingsService from './global-settings.service';
 import AppConfigGuard from '../appconfig/appconfig.guard';
+import defaultValues from '@libs/global-settings/constants/defaultValues';
 
-const mockedGlobalSettingsDto: GlobalSettingsDto = {
-  auth: { mfaEnforcedGroups: [] },
-};
+const mockedGlobalSettingsDto: GlobalSettingsDto = defaultValues;
 
 const mockedGlobalSettingsDbResponse = {
   _id: '123',

--- a/apps/api/src/global-settings/global-settings.controller.ts
+++ b/apps/api/src/global-settings/global-settings.controller.ts
@@ -10,13 +10,15 @@
  * You should have received a copy of the GNU Affero General Public License along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
-import { Body, Controller, Get, Put, Query, UseGuards } from '@nestjs/common';
+import { Body, Controller, Get, Put, Query, UseGuards, UseInterceptors } from '@nestjs/common';
 import { ApiBearerAuth, ApiTags } from '@nestjs/swagger';
 import {
   GLOBAL_SETTINGS_PROJECTION_QUERY_PARAM,
   GLOBAL_SETTINGS_ROOT_ENDPOINT,
 } from '@libs/global-settings/constants/globalSettingsApiEndpoints';
 import type GlobalSettingsDto from '@libs/global-settings/types/globalSettings.dto';
+import { CacheInterceptor, CacheTTL } from '@nestjs/cache-manager';
+import { DEFAULT_CACHE_TTL_MS } from '@libs/common/constants/cacheTtl';
 import AppConfigGuard from '../appconfig/appconfig.guard';
 import GlobalSettingsService from './global-settings.service';
 
@@ -27,6 +29,8 @@ class GlobalSettingsController {
   constructor(private readonly globalSettingsService: GlobalSettingsService) {}
 
   @Get()
+  @UseInterceptors(CacheInterceptor)
+  @CacheTTL(DEFAULT_CACHE_TTL_MS)
   async getGlobalSettings(@Query(GLOBAL_SETTINGS_PROJECTION_QUERY_PARAM) projection?: string) {
     return this.globalSettingsService.getGlobalSettings(projection);
   }

--- a/apps/api/src/global-settings/global-settings.schema.ts
+++ b/apps/api/src/global-settings/global-settings.schema.ts
@@ -14,6 +14,7 @@
 import { Prop, Schema, SchemaFactory } from '@nestjs/mongoose';
 import { Document } from 'mongoose';
 import { AuthSettings, AuthSettingsSchema } from './schemas/global-settings.auth.schema';
+import { GeneralSettings, GeneralSettingsSchema } from './schemas/global-settings.general.schema';
 
 export type GlobalSettingsDocument = GlobalSettings & Document;
 
@@ -24,6 +25,9 @@ export class GlobalSettings {
 
   @Prop({ type: AuthSettingsSchema, required: true })
   auth: AuthSettings;
+
+  @Prop({ type: GeneralSettingsSchema, required: true })
+  general: GeneralSettings;
 
   @Prop({ default: 1 })
   schemaVersion: number;

--- a/apps/api/src/global-settings/global-settings.schema.ts
+++ b/apps/api/src/global-settings/global-settings.schema.ts
@@ -29,7 +29,7 @@ export class GlobalSettings {
   @Prop({ type: GeneralSettingsSchema, required: true })
   general: GeneralSettings;
 
-  @Prop({ default: 1 })
+  @Prop({ default: 2 })
   schemaVersion: number;
 }
 

--- a/apps/api/src/global-settings/global-settings.service.spec.ts
+++ b/apps/api/src/global-settings/global-settings.service.spec.ts
@@ -16,10 +16,10 @@ import { getModelToken } from '@nestjs/mongoose';
 import type { Model, UpdateWriteOpResult } from 'mongoose';
 import type GlobalSettingsDto from '@libs/global-settings/types/globalSettings.dto';
 import { GLOBAL_SETTINGS_PROJECTION_PARAM_AUTH } from '@libs/global-settings/constants/globalSettingsApiEndpoints';
+import defaultValues from '@libs/global-settings/constants/defaultValues';
 import CustomHttpException from '../common/CustomHttpException';
 import GlobalSettingsService from './global-settings.service';
 import { GlobalSettings, GlobalSettingsDocument } from './global-settings.schema';
-import defaultValues from '@libs/global-settings/constants/defaultValues';
 
 class MockGlobalSettings {
   constructor(public data: any) {}

--- a/apps/api/src/global-settings/global-settings.service.spec.ts
+++ b/apps/api/src/global-settings/global-settings.service.spec.ts
@@ -17,9 +17,11 @@ import type { Model, UpdateWriteOpResult } from 'mongoose';
 import type GlobalSettingsDto from '@libs/global-settings/types/globalSettings.dto';
 import { GLOBAL_SETTINGS_PROJECTION_PARAM_AUTH } from '@libs/global-settings/constants/globalSettingsApiEndpoints';
 import defaultValues from '@libs/global-settings/constants/defaultValues';
+import { CACHE_MANAGER } from '@nestjs/cache-manager';
 import CustomHttpException from '../common/CustomHttpException';
 import GlobalSettingsService from './global-settings.service';
 import { GlobalSettings, GlobalSettingsDocument } from './global-settings.schema';
+import cacheManagerMock from '../common/mocks/cacheManagerMock';
 
 class MockGlobalSettings {
   constructor(public data: any) {}
@@ -49,7 +51,14 @@ describe('GlobalSettingsService', () => {
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
-      providers: [GlobalSettingsService, { provide: getModelToken(GlobalSettings.name), useValue: MockGlobalSettings }],
+      providers: [
+        GlobalSettingsService,
+        { provide: getModelToken(GlobalSettings.name), useValue: MockGlobalSettings },
+        {
+          provide: CACHE_MANAGER,
+          useValue: cacheManagerMock,
+        },
+      ],
     }).compile();
 
     service = module.get<GlobalSettingsService>(GlobalSettingsService);

--- a/apps/api/src/global-settings/global-settings.service.spec.ts
+++ b/apps/api/src/global-settings/global-settings.service.spec.ts
@@ -19,6 +19,7 @@ import { GLOBAL_SETTINGS_PROJECTION_PARAM_AUTH } from '@libs/global-settings/con
 import CustomHttpException from '../common/CustomHttpException';
 import GlobalSettingsService from './global-settings.service';
 import { GlobalSettings, GlobalSettingsDocument } from './global-settings.schema';
+import defaultValues from '@libs/global-settings/constants/defaultValues';
 
 class MockGlobalSettings {
   constructor(public data: any) {}
@@ -44,11 +45,7 @@ describe('GlobalSettingsService', () => {
     create?: jest.Mock;
   };
 
-  const mockGlobalSettingsDto: GlobalSettingsDto = {
-    auth: {
-      mfaEnforcedGroups: [],
-    },
-  };
+  const mockGlobalSettingsDto: GlobalSettingsDto = defaultValues;
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
@@ -71,7 +68,7 @@ describe('GlobalSettingsService', () => {
 
   describe('getGlobalSettings', () => {
     it('should return settings with projection', async () => {
-      const mockData = { auth: { mfaEnforcedGroups: [] } };
+      const mockData = defaultValues;
       model.findOne?.mockReturnValue({ lean: () => Promise.resolve(mockData) });
 
       const result = await service.getGlobalSettings(GLOBAL_SETTINGS_PROJECTION_PARAM_AUTH);

--- a/apps/api/src/global-settings/global-settings.service.spec.ts
+++ b/apps/api/src/global-settings/global-settings.service.spec.ts
@@ -68,12 +68,11 @@ describe('GlobalSettingsService', () => {
 
   describe('getGlobalSettings', () => {
     it('should return settings with projection', async () => {
-      const mockData = defaultValues;
-      model.findOne?.mockReturnValue({ lean: () => Promise.resolve(mockData) });
+      model.findOne?.mockReturnValue({ lean: () => Promise.resolve(mockGlobalSettingsDto) });
 
       const result = await service.getGlobalSettings(GLOBAL_SETTINGS_PROJECTION_PARAM_AUTH);
       expect(model.findOne).toHaveBeenCalledWith({}, GLOBAL_SETTINGS_PROJECTION_PARAM_AUTH);
-      expect(result).toEqual(mockData);
+      expect(result).toEqual(mockGlobalSettingsDto);
     });
 
     it('should return null if error occurs', async () => {

--- a/apps/api/src/global-settings/global-settings.service.ts
+++ b/apps/api/src/global-settings/global-settings.service.ts
@@ -40,7 +40,6 @@ class GlobalSettingsService implements OnModuleInit {
     await this.globalSettingsModel.create({
       singleton: true,
       ...defaultValues,
-      schemaVersion: 1,
     });
 
     Logger.log(`Imported default values`, GlobalSettings.name);

--- a/apps/api/src/global-settings/global-settings.service.ts
+++ b/apps/api/src/global-settings/global-settings.service.ts
@@ -53,7 +53,11 @@ class GlobalSettingsService implements OnModuleInit {
   }
 
   async invalidateCache(): Promise<void> {
-    await this.cacheManager.del(`/${EDU_API_ROOT}/${GLOBAL_SETTINGS_ROOT_ENDPOINT}`);
+    try {
+      await this.cacheManager.del(`/${EDU_API_ROOT}/${GLOBAL_SETTINGS_ROOT_ENDPOINT}`);
+    } catch (error) {
+      Logger.warn(`Failed to invalidate cache for GlobalSettings: ${(error as Error).message}`, GlobalSettings.name);
+    }
   }
 
   async getGlobalSettings(projection?: string) {

--- a/apps/api/src/global-settings/migrations/globalSettingsMigrationsList.ts
+++ b/apps/api/src/global-settings/migrations/globalSettingsMigrationsList.ts
@@ -10,17 +10,9 @@
  * You should have received a copy of the GNU Affero General Public License along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
-import { Global, Module } from '@nestjs/common';
-import { MongooseModule } from '@nestjs/mongoose';
-import AppConfigController from './appconfig.controller';
-import AppConfigService from './appconfig.service';
-import { AppConfig, AppConfigSchema } from './appconfig.schema';
+import migration000 from './migration000';
 
-@Global()
-@Module({
-  imports: [MongooseModule.forFeature([{ name: AppConfig.name, schema: AppConfigSchema }])],
-  controllers: [AppConfigController],
-  providers: [AppConfigService],
-  exports: [AppConfigService],
-})
-export default class AppConfigModule {}
+// Add new migrations here
+const globalSettingsMigrationsList = [migration000];
+
+export default globalSettingsMigrationsList;

--- a/apps/api/src/global-settings/migrations/migration000.ts
+++ b/apps/api/src/global-settings/migrations/migration000.ts
@@ -1,0 +1,52 @@
+/*
+ * LICENSE
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import { Logger } from '@nestjs/common';
+import { Migration } from '../../migration/migration.type';
+import { GlobalSettingsDocument } from '../global-settings.schema';
+
+const migration000: Migration<GlobalSettingsDocument> = {
+  name: '000-add-general-settings',
+  version: 2,
+  execute: async (model) => {
+    const previousSchemaVersion = 1;
+    const newSchemaVersion = 2;
+
+    const unprocessedDocuments = await model.find({ schemaVersion: previousSchemaVersion });
+    if (unprocessedDocuments.length === 0) {
+      return;
+    }
+    Logger.log(`${unprocessedDocuments?.length} documents to update...`);
+
+    // eslint-disable-next-line no-underscore-dangle
+    const ids = unprocessedDocuments.map((doc) => doc._id);
+
+    const defaultLandingPage = {
+      isCustomLandingPageEnabled: false,
+      appName: '',
+    };
+
+    const result = await model.updateMany(
+      { _id: { $in: ids } },
+      {
+        $set: {
+          'general.defaultLandingPage': defaultLandingPage,
+          schemaVersion: newSchemaVersion,
+        },
+      },
+    );
+
+    Logger.log(`Migration completed: ${result.modifiedCount} documents updated`);
+  },
+};
+
+export default migration000;

--- a/apps/api/src/global-settings/schemas/global-settings.default-landing-page.schema.ts
+++ b/apps/api/src/global-settings/schemas/global-settings.default-landing-page.schema.ts
@@ -10,17 +10,18 @@
  * You should have received a copy of the GNU Affero General Public License along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
-import { Global, Module } from '@nestjs/common';
-import { MongooseModule } from '@nestjs/mongoose';
-import AppConfigController from './appconfig.controller';
-import AppConfigService from './appconfig.service';
-import { AppConfig, AppConfigSchema } from './appconfig.schema';
+import { Prop, Schema, SchemaFactory } from '@nestjs/mongoose';
+import { Document } from 'mongoose';
 
-@Global()
-@Module({
-  imports: [MongooseModule.forFeature([{ name: AppConfig.name, schema: AppConfigSchema }])],
-  controllers: [AppConfigController],
-  providers: [AppConfigService],
-  exports: [AppConfigService],
-})
-export default class AppConfigModule {}
+export type DefaultLandingPageDocument = DefaultLandingPage & Document;
+
+@Schema({ _id: false })
+export class DefaultLandingPage {
+  @Prop({ default: false })
+  isCustomLandingPageEnabled: boolean;
+
+  @Prop({ default: '' })
+  appName: string;
+}
+
+export const DefaultLandingPageSchema = SchemaFactory.createForClass(DefaultLandingPage);

--- a/apps/api/src/global-settings/schemas/global-settings.general.schema.ts
+++ b/apps/api/src/global-settings/schemas/global-settings.general.schema.ts
@@ -10,17 +10,16 @@
  * You should have received a copy of the GNU Affero General Public License along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
-import { Global, Module } from '@nestjs/common';
-import { MongooseModule } from '@nestjs/mongoose';
-import AppConfigController from './appconfig.controller';
-import AppConfigService from './appconfig.service';
-import { AppConfig, AppConfigSchema } from './appconfig.schema';
+import { Prop, Schema, SchemaFactory } from '@nestjs/mongoose';
+import { Document } from 'mongoose';
+import { DefaultLandingPage } from './global-settings.default-landing-page.schema';
 
-@Global()
-@Module({
-  imports: [MongooseModule.forFeature([{ name: AppConfig.name, schema: AppConfigSchema }])],
-  controllers: [AppConfigController],
-  providers: [AppConfigService],
-  exports: [AppConfigService],
-})
-export default class AppConfigModule {}
+export type GeneralSettingsDocument = GeneralSettings & Document;
+
+@Schema({ _id: false })
+export class GeneralSettings {
+  @Prop({ type: DefaultLandingPage })
+  defaultLandingPage: DefaultLandingPage;
+}
+
+export const GeneralSettingsSchema = SchemaFactory.createForClass(GeneralSettings);

--- a/apps/api/src/logging/logging.interceptor.ts
+++ b/apps/api/src/logging/logging.interceptor.ts
@@ -21,6 +21,7 @@ const logLevel = process.env.EDUI_LOG_LEVEL;
 
 @Injectable()
 class LoggingInterceptor implements NestInterceptor {
+  // eslint-disable-next-line @typescript-eslint/class-methods-use-this
   intercept(context: ExecutionContext, next: CallHandler): Observable<unknown> {
     if (context.getType() !== 'http') {
       return next.handle();

--- a/apps/api/src/migration/migration.service.ts
+++ b/apps/api/src/migration/migration.service.ts
@@ -10,11 +10,10 @@
  * You should have received a copy of the GNU Affero General Public License along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
-import { Injectable, Logger } from '@nestjs/common';
+import { Logger } from '@nestjs/common';
 import { Model } from 'mongoose';
 import { Migration } from './migration.type';
 
-@Injectable()
 class MigrationService {
   static async runMigrations<MigrationModel>(model: Model<MigrationModel>, migrations: Migration<MigrationModel>[]) {
     Logger.log(`Executing ${model.modelName}: ${migrations.length} migrations`, MigrationService.name);

--- a/apps/frontend/src/components/GlobalHooksWrapper.tsx
+++ b/apps/frontend/src/components/GlobalHooksWrapper.tsx
@@ -18,6 +18,7 @@ import type UserDto from '@libs/user/types/user.dto';
 import useSseStore from '@/store/useSseStore';
 import useEduApiStore from '@/store/EduApiStore/useEduApiStore';
 import isDev from '@libs/common/constants/isDev';
+import useGlobalSettingsApiStore from '@/pages/Settings/GlobalSettings/useGlobalSettingsApiStore';
 import useAppConfigsStore from '../pages/Settings/AppConfig/appConfigsStore';
 import useUserStore from '../store/UserStore/UserStore';
 import useLogout from '../hooks/useLogout';
@@ -27,6 +28,7 @@ import useTokenEventListeners from '../hooks/useTokenEventListener';
 const GlobalHooksWrapper: React.FC<{ children: React.ReactNode }> = ({ children }) => {
   const auth = useAuth();
   const { getAppConfigs } = useAppConfigsStore();
+  const { getGlobalSettings } = useGlobalSettingsApiStore();
   const { getIsEduApiHealthy } = useEduApiStore();
   const { isAuthenticated, eduApiToken, setEduApiToken, user, getWebdavKey } = useUserStore();
   const { lmnApiToken, setLmnApiToken } = useLmnApiStore();
@@ -59,9 +61,10 @@ const GlobalHooksWrapper: React.FC<{ children: React.ReactNode }> = ({ children 
   useNotifications();
 
   useEffect(() => {
-    const handleGetAppConfigs = async () => {
+    const getInitialAppData = async () => {
       const isApiResponding = await getIsEduApiHealthy();
       if (isApiResponding) {
+        void getGlobalSettings();
         void getAppConfigs();
         return;
       }
@@ -69,7 +72,7 @@ const GlobalHooksWrapper: React.FC<{ children: React.ReactNode }> = ({ children 
     };
 
     if (isAuthenticated) {
-      void handleGetAppConfigs();
+      void getInitialAppData();
     }
   }, [isAuthenticated]);
 

--- a/apps/frontend/src/components/structure/DefaultLandingPageAfterLogin.tsx
+++ b/apps/frontend/src/components/structure/DefaultLandingPageAfterLogin.tsx
@@ -1,0 +1,43 @@
+/*
+ * LICENSE
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import React, { useEffect } from 'react';
+import useGlobalSettingsApiStore from '@/pages/Settings/GlobalSettings/useGlobalSettingsApiStore';
+import { useNavigate } from 'react-router-dom';
+import CircleLoader from '@/components/ui/Loading/CircleLoader';
+
+const DefaultLandingPageAfterLogin = () => {
+  const { globalSettings } = useGlobalSettingsApiStore();
+  const navigate = useNavigate();
+  const { isCustomLandingPageEnabled, appName } = globalSettings.general.defaultLandingPage;
+
+  useEffect(() => {
+    if (isCustomLandingPageEnabled === undefined) return;
+
+    if (isCustomLandingPageEnabled) {
+      navigate(`/${appName}`, { replace: true });
+    } else {
+      navigate('/', { replace: true });
+    }
+  }, [
+    globalSettings.general.defaultLandingPage.isCustomLandingPageEnabled,
+    globalSettings.general.defaultLandingPage.appName,
+  ]);
+
+  if (isCustomLandingPageEnabled === undefined) {
+    return <CircleLoader className="absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2" />;
+  }
+
+  return null;
+};
+
+export default DefaultLandingPageAfterLogin;

--- a/apps/frontend/src/components/ui/AccordionSH.tsx
+++ b/apps/frontend/src/components/ui/AccordionSH.tsx
@@ -56,7 +56,7 @@ const AccordionContent = React.forwardRef<
 >(({ className, children, ...props }, ref) => (
   <AccordionPrimitive.Content
     ref={ref}
-    className="overflow-hidden text-sm data-[state=closed]:animate-accordion-up data-[state=open]:animate-accordion-down"
+    className="overflow-hidden text-sm data-[state=closed]:animate-accordion-up data-[state=open]:animate-accordion-down data-[state=open]:overflow-visible"
     {...props}
   >
     <div className={cn('pb-4 pt-0', className)}>{children}</div>

--- a/apps/frontend/src/components/ui/DropdownSelect/AppDropdownSelectFormField.tsx
+++ b/apps/frontend/src/components/ui/DropdownSelect/AppDropdownSelectFormField.tsx
@@ -18,17 +18,20 @@ import { FormControl, FormFieldSH, FormItem } from '@/components/ui/Form';
 import { DropdownSelect } from '@/components';
 import { FieldValues, Path, PathValue, UseFormReturn } from 'react-hook-form';
 import { useTranslation } from 'react-i18next';
+import DropdownVariant from '@libs/ui/types/DropdownVariant';
 
 type AppDropdownSelectFormFieldProps<T extends FieldValues> = {
   form: UseFormReturn<T>;
   appNamePath?: Path<T>;
   initialValue?: PathValue<T, Path<T>>;
+  variant: DropdownVariant;
 };
 
 const AppDropdownSelectFormField = <T extends FieldValues>({
   form,
   appNamePath = 'appName' as Path<T>,
   initialValue,
+  variant,
 }: AppDropdownSelectFormFieldProps<T>) => {
   const { getAppConfigs, appConfigs } = useAppConfigsStore();
   const { t } = useTranslation();
@@ -56,7 +59,7 @@ const AppDropdownSelectFormField = <T extends FieldValues>({
               options={appNameOptions}
               selectedVal={field.value}
               handleChange={field.onChange}
-              variant="dialog"
+              variant={variant}
             />
           </FormControl>
         </FormItem>

--- a/apps/frontend/src/components/ui/DropdownSelect/AppDropdownSelectFormField.tsx
+++ b/apps/frontend/src/components/ui/DropdownSelect/AppDropdownSelectFormField.tsx
@@ -1,0 +1,68 @@
+/*
+ * LICENSE
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import React, { useEffect } from 'react';
+import getDisplayName from '@/utils/getDisplayName';
+import useAppConfigsStore from '@/pages/Settings/AppConfig/appConfigsStore';
+import useLanguage from '@/hooks/useLanguage';
+import { FormControl, FormFieldSH, FormItem } from '@/components/ui/Form';
+import { DropdownSelect } from '@/components';
+import { FieldValues, Path, PathValue, UseFormReturn } from 'react-hook-form';
+import { useTranslation } from 'react-i18next';
+
+type AppDropdownSelectFormFieldProps<T extends FieldValues> = {
+  form: UseFormReturn<T>;
+  appNamePath?: Path<T>;
+  initialValue?: PathValue<T, Path<T>>;
+};
+
+const AppDropdownSelectFormField = <T extends FieldValues>({
+  form,
+  appNamePath = 'appName' as Path<T>,
+  initialValue,
+}: AppDropdownSelectFormFieldProps<T>) => {
+  const { getAppConfigs, appConfigs } = useAppConfigsStore();
+  const { t } = useTranslation();
+  const { language } = useLanguage();
+
+  useEffect(() => {
+    void getAppConfigs();
+  }, []);
+
+  const appNameOptions = appConfigs.map((appConfig) => ({
+    id: appConfig.name,
+    name: getDisplayName(appConfig, language),
+  }));
+
+  return (
+    <FormFieldSH
+      control={form.control}
+      name={appNamePath}
+      defaultValue={initialValue}
+      render={({ field }) => (
+        <FormItem>
+          <p className="font-bold">{t('common.application')}</p>
+          <FormControl>
+            <DropdownSelect
+              options={appNameOptions}
+              selectedVal={field.value}
+              handleChange={field.onChange}
+              variant="dialog"
+            />
+          </FormControl>
+        </FormItem>
+      )}
+    />
+  );
+};
+
+export default AppDropdownSelectFormField;

--- a/apps/frontend/src/components/ui/DropdownSelect/DropdownSelect.tsx
+++ b/apps/frontend/src/components/ui/DropdownSelect/DropdownSelect.tsx
@@ -103,7 +103,7 @@ const DropdownSelect: React.FC<DropdownProps> = ({
       </div>
       <div className={cn(styles.arrow, { [styles.open]: isOpen, [styles.up]: openToTop })} />
       <div
-        className={cn('scrollbar-thin', styles.options, {
+        className={cn('shadow-xl scrollbar-thin', styles.options, {
           [styles.open]: isOpen,
           [styles.up]: openToTop,
           'bg-background text-foreground': variant === 'default',

--- a/apps/frontend/src/locales/de/translation.json
+++ b/apps/frontend/src/locales/de/translation.json
@@ -794,8 +794,12 @@
     "globalSettings": {
       "title": "Globale Einstellungen",
       "security": "Sicherheit",
+      "general": "Allgemein",
+      "defaultLandingPageTitle": "Standardanwendung nach dem Login",
+      "defaultLandingPageDescription": "Hier kann festgelegt werden, welche Anwendung für Nutzer standardmäßig nach dem Login angezeigt werden soll.",
+      "defaultLandingPageSwitchDescription": "Bei Aktivierung erfolgt die Weiterleitung der Nutzer nach erfolgreichem Login nicht zum Dashboard, sondern zu der an dieser Stelle konfigurierten Anwendung.",
       "multiFactorAuthentication": "Zwei-Faktor-Authentisierung",
-      "description": "Hier kann festgelegt werden, für welche Nutzergruppen die Zwei-Faktor-Authentisierung erzwungen werden soll.",
+      "mfaDescription": "Hier kann festgelegt werden, für welche Nutzergruppen die Zwei-Faktor-Authentisierung erzwungen werden soll.",
       "selectUserGroups": "Nutzergruppen auswählen, für welche das MFA-Setup erzwungen wird.",
       "updateSuccessful": "Einstellung erfolgreich aktualisiert.",
       "errors": {

--- a/apps/frontend/src/locales/en/translation.json
+++ b/apps/frontend/src/locales/en/translation.json
@@ -790,8 +790,12 @@
     "globalSettings": {
       "title": "Global Settings",
       "security": "Security",
+      "general": "General",
+      "defaultLandingPageTitle": "Standard application after login",
+      "defaultLandingPageDescription": "Here you can specify which application should be displayed to users by default after login.",
+      "defaultLandingPageSwitchDescription": "When enabled, users will be redirected upon successful login not to the dashboard, but to the application configured here.",
       "multiFactorAuthentication": "Two-factor authentication",
-      "description": "Here you can specify the user groups for which two-factor authentication is to be enforced.",
+      "mfaDescription": "Here you can specify the user groups for which two-factor authentication is to be enforced.",
       "selectUserGroups": "Select user groups for which the MFA setup is enforced.",
       "updateSuccessful": "Setting updated successfully",
       "errors": {

--- a/apps/frontend/src/pages/LoginPage/LoginPage.tsx
+++ b/apps/frontend/src/pages/LoginPage/LoginPage.tsx
@@ -36,9 +36,9 @@ import SSE_EDU_API_ENDPOINTS from '@libs/sse/constants/sseEndpoints';
 import SSE_MESSAGE_TYPE from '@libs/common/constants/sseMessageType';
 import delay from '@libs/common/utils/delay';
 import type LoginQrSseDto from '@libs/auth/types/loginQrSse.dto';
-import LOGIN_ROUTE from '@libs/auth/constants/loginRoute';
 import PageLayout from '@/components/structure/layout/PageLayout';
 import APPS from '@libs/appconfig/constants/apps';
+import LANDING_PAGE_ROUTE from '@libs/dashboard/constants/landingPageRoute';
 import getLoginFormSchema from './getLoginFormSchema';
 import TotpInput from './components/TotpInput';
 import useAppConfigsStore from '../Settings/AppConfig/appConfigsStore';
@@ -51,7 +51,7 @@ const LoginPage: React.FC = () => {
   const auth = useAuth();
   const { t } = useTranslation();
   const navigate = useNavigate();
-  const location = useLocation();
+  const { state } = useLocation() as { state: LocationState };
   const { eduApiToken, totpIsLoading, isAuthenticated, createOrUpdateUser, setEduApiToken, getTotpStatus } =
     useUserStore();
   const { appConfigs } = useAppConfigsStore();
@@ -145,14 +145,15 @@ const LoginPage: React.FC = () => {
   const isAuthenticatedAppReady = isAppConfigReady && isAuthenticated;
 
   useEffect(() => {
-    if (isAuthenticatedAppReady) {
-      const { from } = (location?.state ?? { from: '/' }) as LocationState;
-      const toLocation = from === LOGIN_ROUTE ? '/' : from;
-      navigate(toLocation, {
-        replace: true,
-      });
+    if (!isAuthenticatedAppReady) return;
+
+    if (state?.from) {
+      navigate(state.from, { replace: true });
+      return;
     }
-  }, [isAuthenticatedAppReady]);
+
+    navigate(LANDING_PAGE_ROUTE, { replace: true });
+  }, [isAuthenticatedAppReady, state?.from]);
 
   useEffect(() => {
     if (!showQrCode || !sessionID) {

--- a/apps/frontend/src/pages/Settings/AppConfig/components/booleanField/AppConfigSwitch.tsx
+++ b/apps/frontend/src/pages/Settings/AppConfig/components/booleanField/AppConfigSwitch.tsx
@@ -13,14 +13,16 @@
 import React from 'react';
 import { Control, FieldValues, Path } from 'react-hook-form';
 import { useTranslation } from 'react-i18next';
-import { AppConfigExtendedOption } from '@libs/appconfig/types/appConfigExtendedOption';
 import { FormControl, FormDescription, FormFieldSH, FormItem, FormMessage } from '@/components/ui/Form';
 import Switch from '@/components/ui/Switch';
 
 type AppConfigSwitchProps<T extends FieldValues> = {
   fieldPath: Path<T>;
   control: Control<T>;
-  option: AppConfigExtendedOption;
+  option: {
+    title: string;
+    description: string;
+  };
 };
 
 const AppConfigSwitch = <T extends FieldValues>({ fieldPath, control, option }: AppConfigSwitchProps<T>) => {

--- a/apps/frontend/src/pages/Settings/GlobalSettings/GlobalSettings.tsx
+++ b/apps/frontend/src/pages/Settings/GlobalSettings/GlobalSettings.tsx
@@ -99,10 +99,10 @@ const GlobalSettings: React.FC = () => {
         <Form {...form}>
           <form onSubmit={handleSubmit(onSubmit)}>
             <AccordionItem value="general">
-              <AccordionTrigger className="peer flex">
+              <AccordionTrigger className="flex">
                 <h4>{t('settings.globalSettings.general')}</h4>
               </AccordionTrigger>
-              <AccordionContent className="space-y-2 overflow-hidden px-1 text-p peer-[data-state=open]:overflow-visible">
+              <AccordionContent className="space-y-2 px-1 text-p">
                 <p className="text-xl font-bold">{t('settings.globalSettings.defaultLandingPageTitle')}</p>
                 <AppConfigSwitch
                   fieldPath="general.defaultLandingPage.isCustomLandingPageEnabled"
@@ -123,10 +123,10 @@ const GlobalSettings: React.FC = () => {
             </AccordionItem>
 
             <AccordionItem value="security">
-              <AccordionTrigger className="peer flex">
+              <AccordionTrigger className="flex">
                 <h4>{t('settings.globalSettings.multiFactorAuthentication')}</h4>
               </AccordionTrigger>
-              <AccordionContent className="space-y-2 overflow-hidden px-1 peer-[data-state=open]:overflow-visible">
+              <AccordionContent className="space-y-2 px-1">
                 <p className="text-background">{t('settings.globalSettings.mfaDescription')}</p>
                 <FormFieldSH
                   control={control}

--- a/apps/frontend/src/pages/Settings/GlobalSettings/GlobalSettings.tsx
+++ b/apps/frontend/src/pages/Settings/GlobalSettings/GlobalSettings.tsx
@@ -25,6 +25,7 @@ import useAppConfigsStore from '@/pages/Settings/AppConfig/appConfigsStore';
 import defaultValues from '@libs/global-settings/constants/defaultValues';
 import useGlobalSettingsApiStore from './useGlobalSettingsApiStore';
 import GlobalSettingsFloatingButtons from './GlobalSettingsFloatingButtons';
+import { GLOBAL_SETTINGS_AUTH_MFA_ENFORCED_GROUPS } from '@libs/global-settings/constants/globalSettingsApiEndpoints';
 
 const GlobalSettings: React.FC = () => {
   const { t } = useTranslation();
@@ -82,7 +83,7 @@ const GlobalSettings: React.FC = () => {
       if (!acc.some((x) => x.value === g.value)) acc.push(g);
       return acc;
     }, []);
-    setValue('auth.mfaEnforcedGroups', uniqueGroups, { shouldValidate: true });
+    setValue(`auth.${GLOBAL_SETTINGS_AUTH_MFA_ENFORCED_GROUPS}`, uniqueGroups, { shouldValidate: true });
   };
 
   const onSubmit: SubmitHandler<GlobalSettingsDto> = (newGlobalSettings) => {
@@ -134,13 +135,13 @@ const GlobalSettings: React.FC = () => {
                 <p className="text-background">{t('settings.globalSettings.mfaDescription')}</p>
                 <FormFieldSH
                   control={control}
-                  name="auth.mfaEnforcedGroups"
+                  name={`auth.${GLOBAL_SETTINGS_AUTH_MFA_ENFORCED_GROUPS}`}
                   render={() => (
                     <FormItem>
                       <p className="font-bold">{t('permission.groups')}</p>
                       <FormControl>
                         <AsyncMultiSelect<MultipleSelectorGroup>
-                          value={getValues('auth.mfaEnforcedGroups')}
+                          value={getValues(`auth.${GLOBAL_SETTINGS_AUTH_MFA_ENFORCED_GROUPS}`)}
                           onSearch={searchGroups}
                           onChange={handleGroupsChange}
                           placeholder={t('search.type-to-search')}

--- a/apps/frontend/src/pages/Settings/GlobalSettings/GlobalSettings.tsx
+++ b/apps/frontend/src/pages/Settings/GlobalSettings/GlobalSettings.tsx
@@ -23,9 +23,9 @@ import AppConfigSwitch from '@/pages/Settings/AppConfig/components/booleanField/
 import AppDropdownSelectFormField from '@/components/ui/DropdownSelect/AppDropdownSelectFormField';
 import useAppConfigsStore from '@/pages/Settings/AppConfig/appConfigsStore';
 import defaultValues from '@libs/global-settings/constants/defaultValues';
+import { GLOBAL_SETTINGS_AUTH_MFA_ENFORCED_GROUPS } from '@libs/global-settings/constants/globalSettingsApiEndpoints';
 import useGlobalSettingsApiStore from './useGlobalSettingsApiStore';
 import GlobalSettingsFloatingButtons from './GlobalSettingsFloatingButtons';
-import { GLOBAL_SETTINGS_AUTH_MFA_ENFORCED_GROUPS } from '@libs/global-settings/constants/globalSettingsApiEndpoints';
 
 const GlobalSettings: React.FC = () => {
   const { t } = useTranslation();

--- a/apps/frontend/src/pages/Settings/GlobalSettings/GlobalSettings.tsx
+++ b/apps/frontend/src/pages/Settings/GlobalSettings/GlobalSettings.tsx
@@ -99,14 +99,11 @@ const GlobalSettings: React.FC = () => {
         <Form {...form}>
           <form onSubmit={handleSubmit(onSubmit)}>
             <AccordionItem value="general">
-              <AccordionTrigger className="flex text-h4">
+              <AccordionTrigger className="peer flex">
                 <h4>{t('settings.globalSettings.general')}</h4>
               </AccordionTrigger>
-              <AccordionContent
-                className="space-y-2 px-1 text-p"
-                style={{ overflow: 'visible' }}
-              >
-                <h4>{t('settings.globalSettings.defaultLandingPageTitle')}</h4>
+              <AccordionContent className="space-y-2 overflow-hidden px-1 text-p peer-[data-state=open]:overflow-visible">
+                <p className="text-xl font-bold">{t('settings.globalSettings.defaultLandingPageTitle')}</p>
                 <AppConfigSwitch
                   fieldPath="general.defaultLandingPage.isCustomLandingPageEnabled"
                   control={control}
@@ -119,19 +116,17 @@ const GlobalSettings: React.FC = () => {
                   <AppDropdownSelectFormField
                     appNamePath="general.defaultLandingPage.appName"
                     form={form}
+                    variant="default"
                   />
                 )}
               </AccordionContent>
             </AccordionItem>
 
             <AccordionItem value="security">
-              <AccordionTrigger className="flex text-h4">
+              <AccordionTrigger className="peer flex">
                 <h4>{t('settings.globalSettings.multiFactorAuthentication')}</h4>
               </AccordionTrigger>
-              <AccordionContent
-                style={{ overflow: 'visible' }}
-                className="space-y-2 px-1"
-              >
+              <AccordionContent className="space-y-2 overflow-hidden px-1 peer-[data-state=open]:overflow-visible">
                 <p className="text-background">{t('settings.globalSettings.mfaDescription')}</p>
                 <FormFieldSH
                   control={control}

--- a/apps/frontend/src/pages/UserSettings/Security/components/AddUserAccountDialog.tsx
+++ b/apps/frontend/src/pages/UserSettings/Security/components/AddUserAccountDialog.tsx
@@ -21,14 +21,11 @@ import { Form, FormControl, FormDescription, FormFieldSH, FormItem, FormMessage 
 import { zodResolver } from '@hookform/resolvers/zod';
 import useUserStore from '@/store/UserStore/UserStore';
 import { decryptPassword, deriveKey, encryptPassword } from '@libs/common/utils/encryptPassword';
-import { DropdownSelect } from '@/components';
-import useAppConfigsStore from '@/pages/Settings/AppConfig/appConfigsStore';
-import getDisplayName from '@/utils/getDisplayName';
-import useLanguage from '@/hooks/useLanguage';
 import { decodeBase64, encodeBase64 } from '@libs/common/utils/getBase64String';
 import TotpInput from '@/pages/LoginPage/components/TotpInput';
 import cn from '@libs/common/utils/className';
 import type EncryptedPasswordObject from '@libs/common/types/encryptPasswordObject';
+import AppDropdownSelectFormField from '@/components/ui/DropdownSelect/AppDropdownSelectFormField';
 import getUserAccountFormSchema from './getUserAccountSchema';
 
 interface AddUserAccountDialogProps {
@@ -47,9 +44,7 @@ type UserAccountFormValues = {
 
 const AddUserAccountDialog: FC<AddUserAccountDialogProps> = ({ isOpen, isOneRowSelected, keys, handleOpenChange }) => {
   const { t } = useTranslation();
-  const { language } = useLanguage();
   const { userAccounts, addUserAccount, updateUserAccount } = useUserStore();
-  const { appConfigs } = useAppConfigsStore();
   const [enterSafePin, setEnterSafePin] = useState(false);
   const idx = isOneRowSelected ? Number(keys[0]) : undefined;
   const isFirstUserAccount = userAccounts.length === 0;
@@ -69,7 +64,7 @@ const AddUserAccountDialog: FC<AddUserAccountDialogProps> = ({ isOpen, isOneRowS
           safePin: '',
         };
 
-  const form = useForm({
+  const form = useForm<UserAccountFormValues>({
     mode: 'onSubmit',
     resolver: zodResolver(getUserAccountFormSchema(t)),
     defaultValues: initialFormValues,
@@ -132,33 +127,14 @@ const AddUserAccountDialog: FC<AddUserAccountDialogProps> = ({ isOpen, isOneRowS
     handleClose();
   };
 
-  const appNameOptions = appConfigs.map((appConfig) => ({
-    id: appConfig.name,
-    name: getDisplayName(appConfig, language),
-  }));
-
   const getDialogBody = () => (
     <Form {...form}>
       <form onSubmit={form.handleSubmit(onSubmit)}>
         {!enterSafePin && (
           <div className="flex flex-col gap-4">
-            <FormFieldSH
-              control={form.control}
-              name="appName"
-              defaultValue={initialFormValues.appName}
-              render={({ field }) => (
-                <FormItem>
-                  <p className="font-bold">{t('common.application')}</p>
-                  <FormControl>
-                    <DropdownSelect
-                      options={appNameOptions}
-                      selectedVal={field.value}
-                      handleChange={field.onChange}
-                      variant="dialog"
-                    />
-                  </FormControl>
-                </FormItem>
-              )}
+            <AppDropdownSelectFormField
+              form={form}
+              initialValue={initialFormValues.appName}
             />
             <FormField
               labelTranslationId={t('common.username')}

--- a/apps/frontend/src/pages/UserSettings/Security/components/AddUserAccountDialog.tsx
+++ b/apps/frontend/src/pages/UserSettings/Security/components/AddUserAccountDialog.tsx
@@ -135,6 +135,7 @@ const AddUserAccountDialog: FC<AddUserAccountDialogProps> = ({ isOpen, isOneRowS
             <AppDropdownSelectFormField
               form={form}
               initialValue={initialFormValues.appName}
+              variant="dialog"
             />
             <FormField
               labelTranslationId={t('common.username')}

--- a/apps/frontend/src/router/routes/PrivateRoutes.tsx
+++ b/apps/frontend/src/router/routes/PrivateRoutes.tsx
@@ -35,9 +35,11 @@ import getFileSharingRoutes from '@/router/routes/FileSharingRoutes';
 import type AppConfigDto from '@libs/appconfig/types/appConfigDto';
 import APPS from '@libs/appconfig/constants/apps';
 import BulletinBoardPage from '@/pages/BulletinBoard/BulletinBoardPage';
-import DashboardPage from '../../pages/Dashboard/DashboardPage';
-import getEmbeddedRoutes from './EmbeddedAppRoutes';
+import DefaultLandingPageAfterLogin from '@/components/structure/DefaultLandingPageAfterLogin';
+import DashboardPage from '@/pages/Dashboard/DashboardPage';
+import LANDING_PAGE_ROUTE from '@libs/dashboard/constants/landingPageRoute';
 import ProtectedRoute from './ProtectedRoute';
+import getEmbeddedRoutes from './EmbeddedAppRoutes';
 
 const getPrivateRoutes = (appConfigs: AppConfigDto[]) => (
   <>
@@ -45,6 +47,11 @@ const getPrivateRoutes = (appConfigs: AppConfigDto[]) => (
     {getFramedRoutes(appConfigs)}
     {getNativeAppRoutes(appConfigs)}
     {getEmbeddedRoutes(appConfigs)}
+
+    <Route
+      path={LANDING_PAGE_ROUTE}
+      element={<DefaultLandingPageAfterLogin />}
+    />
 
     <Route
       path="/"

--- a/libs/src/dashboard/constants/landingPageRoute.ts
+++ b/libs/src/dashboard/constants/landingPageRoute.ts
@@ -10,17 +10,6 @@
  * You should have received a copy of the GNU Affero General Public License along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
-import { Global, Module } from '@nestjs/common';
-import { MongooseModule } from '@nestjs/mongoose';
-import AppConfigController from './appconfig.controller';
-import AppConfigService from './appconfig.service';
-import { AppConfig, AppConfigSchema } from './appconfig.schema';
+const LANDING_PAGE_ROUTE = '/landing-page';
 
-@Global()
-@Module({
-  imports: [MongooseModule.forFeature([{ name: AppConfig.name, schema: AppConfigSchema }])],
-  controllers: [AppConfigController],
-  providers: [AppConfigService],
-  exports: [AppConfigService],
-})
-export default class AppConfigModule {}
+export default LANDING_PAGE_ROUTE;

--- a/libs/src/global-settings/constants/defaultValues.ts
+++ b/libs/src/global-settings/constants/defaultValues.ts
@@ -10,17 +10,16 @@
  * You should have received a copy of the GNU Affero General Public License along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
-import { Global, Module } from '@nestjs/common';
-import { MongooseModule } from '@nestjs/mongoose';
-import AppConfigController from './appconfig.controller';
-import AppConfigService from './appconfig.service';
-import { AppConfig, AppConfigSchema } from './appconfig.schema';
+import GlobalSettingsDto from '@libs/global-settings/types/globalSettings.dto';
 
-@Global()
-@Module({
-  imports: [MongooseModule.forFeature([{ name: AppConfig.name, schema: AppConfigSchema }])],
-  controllers: [AppConfigController],
-  providers: [AppConfigService],
-  exports: [AppConfigService],
-})
-export default class AppConfigModule {}
+const defaultValues: GlobalSettingsDto = {
+  auth: { mfaEnforcedGroups: [] },
+  general: {
+    defaultLandingPage: {
+      isCustomLandingPageEnabled: undefined,
+      appName: '',
+    },
+  },
+};
+
+export default defaultValues;

--- a/libs/src/global-settings/constants/globalSettingsApiEndpoints.ts
+++ b/libs/src/global-settings/constants/globalSettingsApiEndpoints.ts
@@ -13,5 +13,6 @@
 export const GLOBAL_SETTINGS_ROOT_ENDPOINT = 'global-settings';
 export const GLOBAL_SETTINGS_PROJECTION_QUERY_PARAM = 'projection';
 export const GLOBAL_SETTINGS_PROJECTION_PARAM_AUTH = 'auth';
+export const GLOBAL_SETTINGS_PROJECTION_PARAM_GENERAL = 'general';
 
 export const GLOBAL_SETTINGS_AUTH_MFA_ENFORCED_GROUPS = 'mfaEnforcedGroups';

--- a/libs/src/global-settings/types/globalSettings.dto.ts
+++ b/libs/src/global-settings/types/globalSettings.dto.ts
@@ -20,6 +20,14 @@ type GlobalSettingsAuth = {
 class GlobalSettingsDto {
   @ValidateNested()
   auth: GlobalSettingsAuth;
+
+  @ValidateNested()
+  general: {
+    defaultLandingPage: {
+      isCustomLandingPageEnabled: boolean | undefined;
+      appName: string;
+    };
+  };
 }
 
 export default GlobalSettingsDto;


### PR DESCRIPTION
- Remove unnecessary imports of MigrationService (it has only 1 static method, so it has not to be injected)
- Add better logging in DockerService
- Add `generalSettings` with `defaultLandingPage` options to general settings
- Add migration to add the new fields
- Add a new `<DefaultLandingPageAfterLogin>` component that is the first page after the login
- Extract the `<AppDropdownSelectFormField>` component for reusability
- Add the possibility to configure the default landing page in the admin settings