### PR TITLE
496: Addition - Update share QR-code dialog

### DIFF
--- a/apps/frontend/src/components/shared/SharePublicQRDialog.tsx
+++ b/apps/frontend/src/components/shared/SharePublicQRDialog.tsx
@@ -36,10 +36,6 @@ const SharePublicQRDialog = ({
     <QRCodeWithCopyButton
       url={url}
       titleTranslationId={t(descriptionTranslationId)}
-      toasterTranslationIds={{
-        success: 'common.savedToClipboard',
-        error: 'common.savedToClipboardError',
-      }}
     />
   );
 

--- a/apps/frontend/src/components/ui/QRCodeWithCopyButton.tsx
+++ b/apps/frontend/src/components/ui/QRCodeWithCopyButton.tsx
@@ -10,47 +10,40 @@
  * You should have received a copy of the GNU Affero General Public License along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
-import QRCodeDisplay from '@/components/ui/QRCodeDisplay';
-import { Button } from '@/components/shared/Button';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
-import ToasterTranslationIds from '@libs/ui/types/toasterTranslationIds';
-import copyToClipboard from '@/utils/copyToClipboard';
+import { MdFileCopy } from 'react-icons/md';
 import { Sizes } from '@libs/ui/types/sizes';
+import copyToClipboard from '@/utils/copyToClipboard';
+import Input from '@/components/shared/Input';
+import QRCodeDisplay from '@/components/ui/QRCodeDisplay';
 
 interface QRCodeWithCopyButtonProps {
   url: string;
   titleTranslationId: string;
-  toasterTranslationIds?: ToasterTranslationIds;
   qrCodeSize?: Sizes;
 }
 
-const QRCodeWithCopyButton = ({
-  url,
-  qrCodeSize,
-  titleTranslationId,
-  toasterTranslationIds,
-}: QRCodeWithCopyButtonProps) => {
+const QRCodeWithCopyButton = ({ url, qrCodeSize, titleTranslationId }: QRCodeWithCopyButtonProps) => {
   const { t } = useTranslation();
 
   return (
     <>
       <p className="font-bold">{t(titleTranslationId)}</p>
-      <div className="flex flex-col items-center justify-center">
+      <div className="mt-4 flex flex-col items-center justify-center space-y-8">
         <QRCodeDisplay
           value={url}
           size={qrCodeSize}
           className="m-14"
         />
-        <div className="mb-4 mt-4 rounded-xl bg-muted px-2 py-1 text-center">{url}</div>
-        <Button
-          size="lg"
-          type="button"
-          variant="btn-collaboration"
-          onClick={() => copyToClipboard(url, toasterTranslationIds)}
-        >
-          {t('common.copy.doCopy')}
-        </Button>
+        <Input
+          type="text"
+          value={url}
+          readOnly
+          className="w-fit min-w-[550px] cursor-pointer"
+          onClick={() => copyToClipboard(url)}
+          icon={<MdFileCopy />}
+        />
       </div>
     </>
   );

--- a/apps/frontend/src/locales/de/translation.json
+++ b/apps/frontend/src/locales/de/translation.json
@@ -1032,8 +1032,6 @@
     "back": "Zurück",
     "confirm": "Bestätigen",
     "share": "Teilen",
-    "savedToClipboard": "In die Zwischenablage kopiert.",
-    "savedToClipboardError": "Konnte nicht in die Zwischenablage kopiert werden.",
     "answers": "Antworten",
     "error": "Fehler",
     "errors": {

--- a/apps/frontend/src/locales/en/translation.json
+++ b/apps/frontend/src/locales/en/translation.json
@@ -1029,8 +1029,6 @@
     "back": "Back",
     "confirm": "Confirm",
     "share": "Share",
-    "savedToClipboard": "Saved to clipboard.",
-    "savedToClipboardError": "Unable to save into clipboard.",
     "answers": "Answers",
     "error": "Error",
     "errors": {


### PR DESCRIPTION
Splitted from: https://github.com/edulution-io/edulution-ui/pull/649

Addition from 496:
    * Update the copy field for the SharePublicQRDialog to match new copy field from pw manager