### PR TITLE
Bulletin Board: Fix word-break, date and color

### DIFF
--- a/apps/frontend/src/components/shared/WysiwygEditor/WysiwygEditor.css
+++ b/apps/frontend/src/components/shared/WysiwygEditor/WysiwygEditor.css
@@ -50,3 +50,8 @@
   fill: var(--background) !important;
   stroke: var(--background) !important;
 }
+
+.quill-content span {
+  font-size: inherit;
+  letter-spacing: inherit;
+}

--- a/apps/frontend/src/components/shared/WysiwygEditor/WysiwygEditor.tsx
+++ b/apps/frontend/src/components/shared/WysiwygEditor/WysiwygEditor.tsx
@@ -33,6 +33,18 @@ const WysiwygEditor: React.FC<WysiwygEditorProps> = ({ value = '', onChange, onU
 
   const quillRef = useRef<ReactQuill | null>(null);
 
+  const handleFormatChange = (format: 'color' | 'background') => (colorValue: string) => {
+    if (colorValue) {
+      toast.warning(t('warnings.colorMayConflictWithTheme'));
+    }
+
+    const quill = quillRef.current?.getEditor();
+
+    if (quill) {
+      quill.format(format, colorValue);
+    }
+  };
+
   const handleImage = () => {
     const input = document.createElement('input');
     input.setAttribute('type', 'file');
@@ -67,10 +79,13 @@ const WysiwygEditor: React.FC<WysiwygEditorProps> = ({ value = '', onChange, onU
           ['bold', 'italic', 'underline', 'strike', 'blockquote'],
           [{ list: 'ordered' }, { list: 'bullet' }, { indent: '-1' }, { indent: '+1' }],
           ['link', 'image'],
+          [{ color: [] }, { background: [] }],
           ['clean'],
         ],
         handlers: {
           image: handleImage,
+          color: handleFormatChange('color'),
+          background: handleFormatChange('background'),
         },
       },
     }),

--- a/apps/frontend/src/locales/de/translation.json
+++ b/apps/frontend/src/locales/de/translation.json
@@ -1235,7 +1235,7 @@
     "cannotUploadOversized": "Es können keine Dateien größer als 50MB hochgeladen werden."
   },
   "warnings": {
-    "colorMayConflictWithTheme": "Manuelle Einstellung der Farbe kann zu Problemen mit anderen Themes (hell/dunkel) führen."
+    "colorMayConflictWithTheme": "Manuelle Einstellung der Farbe kann zukünftig zu Problemen mit anderen Themes (hell/dunkel) führen. Es wird empfohlen, die Farbe der Schrift immer gleichzeitig mit der Hintergrundfarbe zu setzen."
   },
   "linuxmuster": {
     "title": "LINUXMUSTER",

--- a/apps/frontend/src/locales/de/translation.json
+++ b/apps/frontend/src/locales/de/translation.json
@@ -1234,6 +1234,9 @@
     "oversizedFileDetected": "Zu große Datei entdeckt!",
     "cannotUploadOversized": "Es können keine Dateien größer als 50MB hochgeladen werden."
   },
+  "warnings": {
+    "colorMayConflictWithTheme": "Manuelle Einstellung der Farbe kann zu Problemen mit anderen Themes (hell/dunkel) führen."
+  },
   "linuxmuster": {
     "title": "LINUXMUSTER",
     "sidebar": "Linuxmuster"

--- a/apps/frontend/src/locales/en/translation.json
+++ b/apps/frontend/src/locales/en/translation.json
@@ -1231,7 +1231,7 @@
     "cannotUploadOversized": "Cannot upload oversized files (more than 50 MB)."
   },
   "warnings": {
-    "colorMayConflictWithTheme": "Manual setting of the color can lead to problems with other themes (light/dark)."
+    "colorMayConflictWithTheme": "Manual setting of the color can lead to problems with other themes (light/dark) in the future. It is recommended to always set the color of the font at the same time as the background color."
   },
   "linuxmuster": {
     "title": "LINUXMUSTER",

--- a/apps/frontend/src/locales/en/translation.json
+++ b/apps/frontend/src/locales/en/translation.json
@@ -1230,6 +1230,9 @@
     "oversizedFileDetected": "Oversized file detected!",
     "cannotUploadOversized": "Cannot upload oversized files (more than 50 MB)."
   },
+  "warnings": {
+    "colorMayConflictWithTheme": "Manual setting of the color can lead to problems with other themes (light/dark)."
+  },
   "linuxmuster": {
     "title": "LINUXMUSTER",
     "sidebar": "Linuxmuster"

--- a/apps/frontend/src/pages/BulletinBoard/BulletinBoardEditorial/CreateOrUpdateBulletinDialog.tsx
+++ b/apps/frontend/src/pages/BulletinBoard/BulletinBoardEditorial/CreateOrUpdateBulletinDialog.tsx
@@ -57,8 +57,12 @@ const CreateOrUpdateBulletinDialog = ({ trigger, onSubmit }: BulletinCreateDialo
     attachmentFileNames: selectedBulletinToEdit?.attachmentFileNames || [],
     content: selectedBulletinToEdit?.content || '',
     isActive: selectedBulletinToEdit?.isActive || true,
-    isVisibleEndDate: selectedBulletinToEdit?.isVisibleEndDate || null,
-    isVisibleStartDate: selectedBulletinToEdit?.isVisibleStartDate || null,
+    isVisibleEndDate: selectedBulletinToEdit?.isVisibleEndDate
+      ? new Date(selectedBulletinToEdit.isVisibleEndDate)
+      : null,
+    isVisibleStartDate: selectedBulletinToEdit?.isVisibleStartDate
+      ? new Date(selectedBulletinToEdit.isVisibleStartDate)
+      : null,
   };
 
   const form = useForm<CreateBulletinDto>({

--- a/apps/frontend/src/pages/BulletinBoard/components/BulletinBoardColumnItem.tsx
+++ b/apps/frontend/src/pages/BulletinBoard/components/BulletinBoardColumnItem.tsx
@@ -208,7 +208,7 @@ const BulletinBoardColumnItem = ({
         <h4 className="w-[calc(100%-20px)] overflow-x-hidden text-ellipsis break-normal text-lg font-bold text-background">
           {bulletin.title}
         </h4>
-        <div className="mt-2 text-gray-100">
+        <div className="quill-content mt-2 break-normal text-white">
           {bulletin.content.split(/(<img[^>]*>)/g).map((part) => getProcessedBulletinContent(part))}
         </div>
         {getAuthorDescription()}

--- a/libs/src/bulletinBoard/constants/bulletinEditorFormats.ts
+++ b/libs/src/bulletinBoard/constants/bulletinEditorFormats.ts
@@ -21,6 +21,8 @@ const BULLETIN_EDITOR_FORMATS = [
   'indent',
   'link',
   'image',
+  'color',
+  'background',
 ];
 
 export default BULLETIN_EDITOR_FORMATS;


### PR DESCRIPTION
- Fix word break
- Enable color and background for text
- Fix problem when you edit an existing bulletin with a start or end date set (you could not save it again)