### PR TITLE
904 - Unify tables with actions to use the TableActionFooter and the TableActionCell

### DIFF
--- a/apps/frontend/src/pages/Settings/AppConfig/components/table/AppConfigTable.tsx
+++ b/apps/frontend/src/pages/Settings/AppConfig/components/table/AppConfigTable.tsx
@@ -14,11 +14,11 @@ import React, { useEffect, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { IoAdd, IoRemove } from 'react-icons/io5';
 import { type ContainerInfo } from 'dockerode';
+import TableAction from '@libs/common/types/tableAction';
 import { AppConfigTableConfig } from '@/pages/Settings/AppConfig/components/table/types/appConfigTableConfig';
 import getAppConfigTableConfig from '@/pages/Settings/AppConfig/components/table/getAppConfigTableConfig';
 import useAppConfigTableDialogStore from '@/pages/Settings/AppConfig/components/table/useAppConfigTableDialogStore';
 import ScrollableTable from '@/components/ui/Table/ScrollableTable';
-import { Button } from '@/components/shared/Button';
 import type BulletinCategoryResponseDto from '@libs/bulletinBoard/types/bulletinCategoryResponseDto';
 import VeyonProxyItem from '@libs/veyon/types/veyonProxyItem';
 import ExtendedOptionKeys from '@libs/appconfig/constants/extendedOptionKeys';
@@ -116,6 +116,23 @@ const AppConfigTable: React.FC<AppConfigTableProps> = ({ applicationName, tableI
     }, [isMobileView, isTabletView, hideColumnsInMobileView, hideColumnsInTabletView]);
 
     const getScrollableTable = () => {
+      const tableActions: TableAction<BulletinCategoryResponseDto | ContainerInfo | FileInfoDto | VeyonProxyItem>[] =
+        [];
+      if (showAddButton) {
+        tableActions.push({
+          icon: IoAdd,
+          translationId: 'common.add',
+          onClick: handleAddClick,
+        });
+      }
+      if (showRemoveButton) {
+        tableActions.push({
+          icon: IoRemove,
+          translationId: 'common.remove',
+          onClick: handleRemoveClick,
+        });
+      }
+
       switch (type) {
         case ExtendedOptionKeys.BULLETIN_BOARD_CATEGORY_TABLE: {
           return (
@@ -127,6 +144,7 @@ const AppConfigTable: React.FC<AppConfigTableProps> = ({ applicationName, tableI
               applicationName={applicationName}
               enableRowSelection={false}
               initialColumnVisibility={initialColumnVisibility}
+              actions={tableActions as TableAction<BulletinCategoryResponseDto>[]}
             />
           );
         }
@@ -140,6 +158,7 @@ const AppConfigTable: React.FC<AppConfigTableProps> = ({ applicationName, tableI
               applicationName={applicationName}
               enableRowSelection={false}
               initialColumnVisibility={initialColumnVisibility}
+              actions={tableActions as TableAction<ContainerInfo>[]}
             />
           );
         }
@@ -155,6 +174,7 @@ const AppConfigTable: React.FC<AppConfigTableProps> = ({ applicationName, tableI
               initialColumnVisibility={initialColumnVisibility}
               selectedRows={selectedRows}
               onRowSelectionChange={handleRowSelectionChange}
+              actions={tableActions as TableAction<FileInfoDto>[]}
             />
           );
         }
@@ -168,6 +188,7 @@ const AppConfigTable: React.FC<AppConfigTableProps> = ({ applicationName, tableI
               applicationName={applicationName}
               enableRowSelection={false}
               initialColumnVisibility={initialColumnVisibility}
+              actions={tableActions as TableAction<VeyonProxyItem>[]}
             />
           );
         }
@@ -179,30 +200,6 @@ const AppConfigTable: React.FC<AppConfigTableProps> = ({ applicationName, tableI
     return (
       <div className="mb-8">
         {getScrollableTable()}
-        <div className="flex w-full items-center justify-between gap-2">
-          {showAddButton && (
-            <div className="flex w-full">
-              <Button
-                className="flex h-2 w-full items-center justify-center rounded-md border border-gray-500 hover:bg-accent"
-                onClick={handleAddClick}
-                type="button"
-              >
-                <IoAdd className="text-xl text-background" />
-              </Button>
-            </div>
-          )}
-          {showRemoveButton && (
-            <div className="flex w-full">
-              <Button
-                className="flex h-2 w-full items-center justify-center rounded-md border border-gray-500 hover:bg-accent"
-                onClick={handleRemoveClick}
-                type="button"
-              >
-                <IoRemove className="text-xl text-background" />
-              </Button>
-            </div>
-          )}
-        </div>
         {dialogBody}
       </div>
     );

--- a/apps/frontend/src/pages/Surveys/Editor/dialog/backend-limiter/ChoicesWithBackendLimitTableColumns.tsx
+++ b/apps/frontend/src/pages/Surveys/Editor/dialog/backend-limiter/ChoicesWithBackendLimitTableColumns.tsx
@@ -81,7 +81,7 @@ const ChoicesWithBackendLimitTableColumns: ColumnDef<ChoiceDto>[] = [
             {
               icon: HiTrash,
               translationId: 'common.delete',
-              onClick: () => (row ? removeChoice(row.original.name) : null),
+              onClick: () => (row ? removeChoice(row.original.name) : undefined),
             },
           ]}
           row={row}

--- a/apps/frontend/src/pages/UserSettings/Security/components/UserAccountsTable.tsx
+++ b/apps/frontend/src/pages/UserSettings/Security/components/UserAccountsTable.tsx
@@ -10,14 +10,15 @@
  * You should have received a copy of the GNU Affero General Public License along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useState, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { IoAdd, IoRemove } from 'react-icons/io5';
 import { FiEdit } from 'react-icons/fi';
 import { OnChangeFn, RowSelectionState } from '@tanstack/react-table';
 import ScrollableTable from '@/components/ui/Table/ScrollableTable';
 import APPS from '@libs/appconfig/constants/apps';
-import { Button } from '@/components/shared/Button';
+import TableAction from '@libs/common/types/tableAction';
+import UserAccountDto from '@libs/user/types/userAccount.dto';
 import useUserStore from '@/store/UserStore/UserStore';
 import UserAccountsTableColumns from './UserAccountsTableColumns';
 import AddUserAccountDialog from './AddUserAccountDialog';
@@ -61,6 +62,29 @@ const UserAccountsTable: React.FC = () => {
     setSelectedRows({});
   };
 
+  const tableActions: TableAction<UserAccountDto>[] = useMemo(() => {
+    const actions: TableAction<UserAccountDto>[] = [];
+    if (isOneRowSelected) {
+      actions.push({
+        icon: FiEdit,
+        translationId: 'common.edit',
+        onClick: handleAddClick,
+      });
+    } else {
+      actions.push({
+        icon: IoAdd,
+        translationId: 'common.add',
+        onClick: handleAddClick,
+      });
+    }
+    actions.push({
+      icon: IoRemove,
+      translationId: 'common.remove',
+      onClick: handleRemoveClick,
+    });
+    return actions;
+  }, [isOneRowSelected]);
+
   return (
     <>
       <div>
@@ -77,31 +101,8 @@ const UserAccountsTable: React.FC = () => {
             onRowSelectionChange={handleRowSelectionChange}
             selectedRows={selectedRows}
             isLoading={userAccountsIsLoading}
+            actions={tableActions}
           />
-          <div className="flex w-full items-center justify-between gap-2">
-            <div className="flex w-full">
-              <Button
-                className="flex h-2 w-full items-center justify-center rounded-md border border-gray-500 hover:bg-accent"
-                onClick={handleAddClick}
-                type="button"
-              >
-                {isOneRowSelected ? (
-                  <FiEdit className="text-xl text-background" />
-                ) : (
-                  <IoAdd className="text-xl text-background" />
-                )}
-              </Button>
-            </div>
-            <div className="flex w-full">
-              <Button
-                className="flex h-2 w-full items-center justify-center rounded-md border border-gray-500 hover:bg-accent"
-                onClick={handleRemoveClick}
-                type="button"
-              >
-                <IoRemove className="text-xl text-background" />
-              </Button>
-            </div>
-          </div>
         </div>
       </div>
       <AddUserAccountDialog

--- a/libs/src/common/types/tableAction.ts
+++ b/libs/src/common/types/tableAction.ts
@@ -16,7 +16,7 @@ import { Row } from '@tanstack/react-table';
 interface TableAction<TData> {
   icon: IconType;
   translationId: string;
-  onClick: (row?: Row<TData>) => void;
+  onClick: (row?: Row<TData>) => void | Promise<void>;
   className?: string;
 }
 


### PR DESCRIPTION
Issue: https://github.com/edulution-io/edulution-ui/issues/904

904:
* replace extern buttons with the new buttons from the action table
* for now skipping the password cell from the userAccountsTable (handles show/hide decrypt/encrypt)
 