### PR TITLE
Add launcher with CTRL+K

### DIFF
--- a/apps/frontend/src/components/structure/framing/ResizableWindow/ResizableWindow.tsx
+++ b/apps/frontend/src/components/structure/framing/ResizableWindow/ResizableWindow.tsx
@@ -234,7 +234,7 @@ const ResizableWindow: React.FC<ResizableWindowProps> = ({
         role="button"
         tabIndex={0}
         style={{ height: isMinimized ? DEFAULT_MINIMIZED_BAR_HEIGHT : MAXIMIZED_BAR_HEIGHT }}
-        className={cn('sticky top-0 flex items-center justify-between bg-gray-900 text-white', {
+        className={cn('sticky top-0 flex items-center justify-between bg-gray-900 text-background', {
           'cursor-default': disableDragging,
           'cursor-move hover:bg-gray-800': isMinimized && !isMobileView,
         })}

--- a/apps/frontend/src/components/structure/layout/Overlays.tsx
+++ b/apps/frontend/src/components/structure/layout/Overlays.tsx
@@ -18,6 +18,7 @@ import VDIFrame from '@/pages/DesktopDeployment/VDIFrame';
 import SetupMfaDialog from '@/pages/UserSettings/Security/components/SetupMfaDialog';
 import NativeFrameManager from '@/components/structure/framing/Native/NativeFrameManager';
 import EmbeddedFrameManager from '@/components/structure/framing/EmbeddedFrameManager';
+import Launcher from '@/components/ui/Launcher/Launcher';
 
 const Overlays = () => (
   <>
@@ -28,6 +29,7 @@ const Overlays = () => (
     <NativeFrameManager />
     <CommunityLicenseDialog />
     <SetupMfaDialog />
+    <Launcher />
   </>
 );
 

--- a/apps/frontend/src/components/ui/Launcher/Launcher.tsx
+++ b/apps/frontend/src/components/ui/Launcher/Launcher.tsx
@@ -1,0 +1,51 @@
+/*
+ * LICENSE
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import React, { useCallback, useEffect } from 'react';
+import AdaptiveDialog from '@/components/ui/AdaptiveDialog';
+import useLauncherStore from '@/components/ui/Launcher/useLauncherStore';
+import LauncherAppGrid from '@/components/ui/Launcher/LauncherAppGrid';
+import useModKeyLabel from '@/hooks/useModKeyLabel';
+
+const Launcher = () => {
+  const { isLauncherOpen, toggleLauncher } = useLauncherStore();
+  const modKeyLabel = useModKeyLabel();
+
+  const handleKeyDown = useCallback(
+    (e: KeyboardEvent) => {
+      const isMod = e.ctrlKey || e.metaKey;
+      if (isMod && e.key.toLowerCase() === 'k') {
+        e.preventDefault();
+        toggleLauncher();
+      }
+    },
+    [toggleLauncher],
+  );
+
+  useEffect(() => {
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  }, [handleKeyDown]);
+
+  return (
+    <AdaptiveDialog
+      isOpen={isLauncherOpen}
+      handleOpenChange={toggleLauncher}
+      title=""
+      desktopContentClassName="max-h-[95%] max-w-[90%] z-[999]"
+      mobileContentClassName="h-full z-[999] flex flex-col pb-0"
+      body={<LauncherAppGrid modKeyLabel={modKeyLabel} />}
+    />
+  );
+};
+
+export default Launcher;

--- a/apps/frontend/src/components/ui/Launcher/LauncherAppGrid.tsx
+++ b/apps/frontend/src/components/ui/Launcher/LauncherAppGrid.tsx
@@ -22,6 +22,7 @@ import Input from '@/components/shared/Input';
 import isSubsequence from '@libs/common/utils/string/isSubsequence';
 import useMedia from '@/hooks/useMedia';
 import cn from '@libs/common/utils/className';
+import NotificationCounter from '@/components/ui/Sidebar/SidebarMenuItems/NotificationCounter';
 import SEARCH_INPUT_LABEL from '@libs/ui/constants/launcherSearchInputLabel';
 
 const LauncherAppGrid = ({ modKeyLabel }: { modKeyLabel: string }) => {
@@ -87,7 +88,7 @@ const LauncherAppGrid = ({ modKeyLabel }: { modKeyLabel: string }) => {
 
       <div
         className="mx-auto grid max-h-[full] w-full grid-cols-[repeat(auto-fit,minmax(8rem,auto))] justify-center
-        gap-x-3 gap-y-2 overflow-auto overflow-y-auto pb-10 scrollbar-thin md:max-h-full
+        gap-x-3 gap-y-2 overflow-auto pb-10 scrollbar-thin md:max-h-full
         md:w-[95%] md:grid-cols-[repeat(auto-fit,minmax(12rem,auto))] md:gap-x-6 md:gap-y-5 md:pb-4"
       >
         {filteredApps.length ? (
@@ -99,7 +100,7 @@ const LauncherAppGrid = ({ modKeyLabel }: { modKeyLabel: string }) => {
             >
               <Card
                 className={cn(
-                  'h-26 flex w-full flex-col items-center overflow-hidden border border-muted-light bg-muted-dialog p-5 hover:bg-primary',
+                  'h-26 relative flex w-full flex-col items-center overflow-hidden border border-muted-light bg-muted-dialog p-5 hover:bg-primary',
                   {
                     'bg-muted': index === 0,
                   },
@@ -111,7 +112,13 @@ const LauncherAppGrid = ({ modKeyLabel }: { modKeyLabel: string }) => {
                   alt={app.title}
                   className="h-10 w-10 md:h-14 md:w-14"
                 />
+
                 <p>{app.title}</p>
+
+                <NotificationCounter
+                  count={app.notificationCounter || 0}
+                  className="top-[10px]"
+                />
               </Card>
             </NavLink>
           ))

--- a/apps/frontend/src/components/ui/Launcher/LauncherAppGrid.tsx
+++ b/apps/frontend/src/components/ui/Launcher/LauncherAppGrid.tsx
@@ -22,6 +22,7 @@ import Input from '@/components/shared/Input';
 import isSubsequence from '@libs/common/utils/string/isSubsequence';
 import useMedia from '@/hooks/useMedia';
 import cn from '@libs/common/utils/className';
+import SEARCH_INPUT_LABEL from '@libs/ui/constants/launcherSearchInputLabel';
 
 const LauncherAppGrid = ({ modKeyLabel }: { modKeyLabel: string }) => {
   const { toggleMobileSidebar } = useSidebarStore();
@@ -50,30 +51,34 @@ const LauncherAppGrid = ({ modKeyLabel }: { modKeyLabel: string }) => {
     toggleLauncher();
   }, [toggleMobileSidebar, toggleLauncher]);
 
-  const searchInputLabel = 'launcher.searchApps';
-
-  useEffect(() => {
-    const onKeyDown = (event: KeyboardEvent) => {
+  const handleKeyDown = useCallback(
+    (event: KeyboardEvent) => {
       if (event.key !== 'Enter') return;
 
       const active = document.activeElement;
-
-      if (active instanceof HTMLInputElement && active.getAttribute('aria-label') === searchInputLabel) {
+      if (active instanceof HTMLInputElement && active.getAttribute('aria-label') === SEARCH_INPUT_LABEL) {
         event.preventDefault();
         onClose();
-        navigate(filteredApps[0].link);
+        if (filteredApps.length > 0) {
+          navigate(filteredApps[0].link);
+        }
       }
-    };
+    },
+    [filteredApps, navigate, onClose],
+  );
 
-    window.addEventListener('keydown', onKeyDown);
-    return () => window.removeEventListener('keydown', onKeyDown);
-  }, [filteredApps, navigate, onClose]);
+  useEffect(() => {
+    window.addEventListener('keydown', handleKeyDown);
+    return () => {
+      window.removeEventListener('keydown', handleKeyDown);
+    };
+  }, [handleKeyDown]);
 
   return (
     <>
       <Input
-        placeholder={t(searchInputLabel)}
-        aria-label={searchInputLabel}
+        placeholder={t(SEARCH_INPUT_LABEL)}
+        aria-label={SEARCH_INPUT_LABEL}
         value={search}
         onChange={(event) => setSearch(event.target.value)}
         variant="dialog"
@@ -88,7 +93,7 @@ const LauncherAppGrid = ({ modKeyLabel }: { modKeyLabel: string }) => {
         {filteredApps.length ? (
           filteredApps.map((app, index) => (
             <NavLink
-              key={app.title}
+              key={app.link}
               to={app.link}
               onClick={onClose}
             >

--- a/apps/frontend/src/components/ui/Launcher/LauncherAppGrid.tsx
+++ b/apps/frontend/src/components/ui/Launcher/LauncherAppGrid.tsx
@@ -1,0 +1,135 @@
+/*
+ * LICENSE
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import { Card } from '@/components/shared/Card';
+import { NavLink, useNavigate } from 'react-router-dom';
+import useSidebarStore from '@/components/ui/Sidebar/sidebarStore';
+import useLauncherStore from '@/components/ui/Launcher/useLauncherStore';
+import useLanguage from '@/hooks/useLanguage';
+import { useTranslation } from 'react-i18next';
+import useSidebarItems from '@/hooks/useSidebarItems';
+import Input from '@/components/shared/Input';
+import isSubsequence from '@libs/common/utils/string/isSubsequence';
+import useMedia from '@/hooks/useMedia';
+import cn from '@libs/common/utils/className';
+
+const LauncherAppGrid = ({ modKeyLabel }: { modKeyLabel: string }) => {
+  const { toggleMobileSidebar } = useSidebarStore();
+  const { toggleLauncher } = useLauncherStore();
+  const { language } = useLanguage();
+  const { t } = useTranslation();
+  const [search, setSearch] = useState('');
+  const sidebarItems = useSidebarItems();
+  const navigate = useNavigate();
+  const { isMobileView, isTabletView } = useMedia();
+
+  const filteredApps = useMemo(() => {
+    const searchString = search.trim().toLowerCase();
+
+    if (!searchString) return sidebarItems;
+
+    return sidebarItems.filter((app) => {
+      const name = app.title.toLowerCase();
+
+      return isSubsequence(searchString, name);
+    });
+  }, [sidebarItems, language, search]);
+
+  const onClose = useCallback(() => {
+    toggleMobileSidebar();
+    toggleLauncher();
+  }, [toggleMobileSidebar, toggleLauncher]);
+
+  const searchInputLabel = 'launcher.searchApps';
+
+  useEffect(() => {
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key !== 'Enter') return;
+
+      const active = document.activeElement;
+
+      if (active instanceof HTMLInputElement && active.getAttribute('aria-label') === searchInputLabel) {
+        event.preventDefault();
+        onClose();
+        navigate(filteredApps[0].link);
+      }
+    };
+
+    window.addEventListener('keydown', onKeyDown);
+    return () => window.removeEventListener('keydown', onKeyDown);
+  }, [filteredApps, navigate, onClose]);
+
+  return (
+    <>
+      <Input
+        placeholder={t(searchInputLabel)}
+        aria-label={searchInputLabel}
+        value={search}
+        onChange={(event) => setSearch(event.target.value)}
+        variant="dialog"
+        className="mx-auto my-3 block w-[80%] min-w-[250px] rounded-xl border border-ring px-3 py-2 md:mb-2 md:mt-0 md:w-[400px]"
+      />
+
+      <div
+        className="mx-auto grid max-h-[full] w-full grid-cols-[repeat(auto-fit,minmax(8rem,auto))] justify-center
+        gap-x-3 gap-y-2 overflow-auto overflow-y-auto pb-10 scrollbar-thin md:max-h-full
+        md:w-[95%] md:grid-cols-[repeat(auto-fit,minmax(12rem,auto))] md:gap-x-6 md:gap-y-5 md:pb-4"
+      >
+        {filteredApps.length ? (
+          filteredApps.map((app, index) => (
+            <NavLink
+              key={app.title}
+              to={app.link}
+              onClick={onClose}
+            >
+              <Card
+                className={cn(
+                  'h-26 flex w-full flex-col items-center overflow-hidden border border-muted-light bg-muted-dialog p-5 hover:bg-primary',
+                  {
+                    'bg-muted': index === 0,
+                  },
+                )}
+                variant="text"
+              >
+                <img
+                  src={app.icon}
+                  alt={app.title}
+                  className="h-10 w-10 md:h-14 md:w-14"
+                />
+                <p>{app.title}</p>
+              </Card>
+            </NavLink>
+          ))
+        ) : (
+          <div className="py-16">{t('launcher.noSearchResults')}</div>
+        )}
+      </div>
+
+      {!isMobileView && !isTabletView && (
+        <div className="text-center text-sm text-muted-foreground">
+          <span>{t('launcher.pressShortKey')} </span>
+          <span className="ml-0.5 rounded border-2 border-muted-light bg-muted px-1 py-0.5 text-xs">
+            {modKeyLabel}
+          </span>{' '}
+          +<span className="ml-0.5 rounded border-2 border-muted-light bg-muted px-1 py-0.5 text-xs">K</span>
+          <span className="ml-8">{t('launcher.pressEnterToStartApp')} </span>
+          <span className="ml-0.5 rounded border-2 border-muted-light bg-muted px-1 py-0.5 text-xs">
+            {t('enterKey')}
+          </span>
+        </div>
+      )}
+    </>
+  );
+};
+
+export default LauncherAppGrid;

--- a/apps/frontend/src/components/ui/Launcher/useLauncherStore.ts
+++ b/apps/frontend/src/components/ui/Launcher/useLauncherStore.ts
@@ -10,8 +10,22 @@
  * You should have received a copy of the GNU Affero General Public License along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
-export const INPUT_VARIANT_DEFAULT = 'bg-accent text-secondary placeholder:text-p focus:outline-none';
-export const INPUT_VARIANT_DIALOG = 'bg-muted placeholder:text-p focus:outline-none text-background';
+import { create } from 'zustand';
 
-export const INPUT_DEFAULT =
-  'flex h-9 rounded-md px-3 py-1 text-p text-background shadow-sm transition-colors file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50';
+interface LauncherStore {
+  isLauncherOpen: boolean;
+  reset: () => void;
+  toggleLauncher: () => void;
+}
+
+const initialState = {
+  isLauncherOpen: false,
+};
+
+const useLauncherStore = create<LauncherStore>((set) => ({
+  ...initialState,
+  reset: () => set(initialState),
+  toggleLauncher: () => set((state) => ({ isLauncherOpen: !state.isLauncherOpen })),
+}));
+
+export default useLauncherStore;

--- a/apps/frontend/src/components/ui/Sheet.tsx
+++ b/apps/frontend/src/components/ui/Sheet.tsx
@@ -88,7 +88,7 @@ const SheetContent = React.forwardRef<React.ElementRef<typeof SheetPrimitive.Con
         {children}
         <SheetPrimitive.Close
           className={cn(
-            { 'text-foreground': variant === 'primary' },
+            { 'text-card-foreground': variant === 'primary' },
             { 'text-background': variant === 'secondary' || variant === 'tertiary' },
             'absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity data-[state=open]:bg-secondary hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none',
           )}

--- a/apps/frontend/src/components/ui/Sidebar/Sidebar.tsx
+++ b/apps/frontend/src/components/ui/Sidebar/Sidebar.tsx
@@ -11,71 +11,15 @@
  */
 
 import React from 'react';
-import { useTranslation } from 'react-i18next';
-import APPS from '@libs/appconfig/constants/apps';
-import { Dashboard, SettingsIcon } from '@/assets/icons';
 import useMedia from '@/hooks/useMedia';
-import useLdapGroups from '@/hooks/useLdapGroups';
-import useLanguage from '@/hooks/useLanguage';
-import useAppConfigsStore from '@/pages/Settings/AppConfig/appConfigsStore';
-import useMailsStore from '@/pages/Mail/useMailsStore';
-import useConferenceStore from '@/pages/ConferencePage/ConferencesStore';
-import { SETTINGS_PATH } from '@libs/appconfig/constants/appConfigPaths';
-import getDisplayName from '@/utils/getDisplayName';
-import useBulletinBoardStore from '@/pages/BulletinBoard/useBulletinBoardStore';
-import DASHBOARD_ROUTE from '@libs/dashboard/constants/dashboardRoute';
+import useSidebarItems from '@/hooks/useSidebarItems';
 import DesktopSidebar from './DesktopSidebar';
 import MobileSidebar from './MobileSidebar';
 
 const Sidebar: React.FC = () => {
-  const { t } = useTranslation();
-  const { appConfigs } = useAppConfigsStore();
-  const { isSuperAdmin } = useLdapGroups();
   const { isMobileView } = useMedia();
-  const { language } = useLanguage();
 
-  const { mails } = useMailsStore();
-  const { runningConferences } = useConferenceStore();
-  const { bulletinBoardNotifications } = useBulletinBoardStore();
-
-  const getNotificationCounter = (app: string): number | undefined => {
-    switch (app) {
-      case APPS.MAIL:
-        return mails.length || 0;
-      case APPS.CONFERENCES:
-        return runningConferences.length;
-      case APPS.BULLETIN_BOARD:
-        return bulletinBoardNotifications.length;
-      default:
-        return undefined;
-    }
-  };
-
-  const sidebarItems = [
-    {
-      title: t('dashboard.pageTitle'),
-      link: `${DASHBOARD_ROUTE}`,
-      icon: Dashboard,
-      color: 'bg-ciGreenToBlue',
-    },
-    ...appConfigs.map((item) => ({
-      title: getDisplayName(item, language),
-      link: `/${item.name}`,
-      icon: item.icon,
-      color: 'bg-ciGreenToBlue',
-      notificationCounter: getNotificationCounter(item.name),
-    })),
-    ...(isSuperAdmin
-      ? [
-          {
-            title: t('settings.sidebar'),
-            link: `/${SETTINGS_PATH}`,
-            icon: SettingsIcon,
-            color: 'bg-ciGreenToBlue',
-          },
-        ]
-      : []),
-  ];
+  const sidebarItems = useSidebarItems();
 
   const sidebarProps = {
     sidebarItems,

--- a/apps/frontend/src/components/ui/Sidebar/SidebarMenuItems/LauncherButton.tsx
+++ b/apps/frontend/src/components/ui/Sidebar/SidebarMenuItems/LauncherButton.tsx
@@ -1,0 +1,40 @@
+/*
+ * LICENSE
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import React from 'react';
+import { MobileLogoIcon } from '@/assets/icons';
+import { SIDEBAR_ICON_WIDTH } from '@libs/ui/constants';
+import { useTranslation } from 'react-i18next';
+import useLauncherStore from '@/components/ui/Launcher/useLauncherStore';
+
+const LauncherButton: React.FC = () => {
+  const { t } = useTranslation();
+  const { toggleLauncher } = useLauncherStore();
+
+  return (
+    <button
+      type="button"
+      onClick={toggleLauncher}
+      className="group relative z-50 flex max-h-14 w-full items-center justify-end gap-4 bg-black px-4 py-2 md:block md:px-3"
+    >
+      <p className="text-md font-bold md:hidden">{t('launcher.title')}</p>
+      <img
+        src={MobileLogoIcon}
+        className="g transform rounded-full transition-transform duration-200 group-hover:scale-[1.3]"
+        width={SIDEBAR_ICON_WIDTH}
+        alt="edulution-mobile-logo"
+      />
+    </button>
+  );
+};
+
+export default LauncherButton;

--- a/apps/frontend/src/components/ui/Sidebar/SidebarMenuItems/LauncherButton.tsx
+++ b/apps/frontend/src/components/ui/Sidebar/SidebarMenuItems/LauncherButton.tsx
@@ -15,10 +15,15 @@ import { MobileLogoIcon } from '@/assets/icons';
 import { SIDEBAR_ICON_WIDTH } from '@libs/ui/constants';
 import { useTranslation } from 'react-i18next';
 import useLauncherStore from '@/components/ui/Launcher/useLauncherStore';
+import useSidebarItems from '@/hooks/useSidebarItems';
+import NotificationCounter from '@/components/ui/Sidebar/SidebarMenuItems/NotificationCounter';
 
 const LauncherButton: React.FC = () => {
   const { t } = useTranslation();
   const { toggleLauncher } = useLauncherStore();
+  const sidebarItems = useSidebarItems();
+
+  const totalNotifications = sidebarItems.reduce((sum, item) => sum + (item.notificationCounter ?? 0), 0);
 
   return (
     <button
@@ -27,12 +32,15 @@ const LauncherButton: React.FC = () => {
       className="group relative z-50 flex max-h-14 w-full items-center justify-end gap-4 bg-black px-4 py-2 md:block md:px-3"
     >
       <p className="text-md font-bold md:hidden">{t('launcher.title')}</p>
+
       <img
         src={MobileLogoIcon}
         className="g transform rounded-full transition-transform duration-200 group-hover:scale-[1.3]"
         width={SIDEBAR_ICON_WIDTH}
         alt="edulution-mobile-logo"
       />
+
+      <NotificationCounter count={totalNotifications} />
     </button>
   );
 };

--- a/apps/frontend/src/components/ui/Sidebar/SidebarMenuItems/MobileSidebarItem.tsx
+++ b/apps/frontend/src/components/ui/Sidebar/SidebarMenuItems/MobileSidebarItem.tsx
@@ -16,6 +16,7 @@ import { SIDEBAR_ICON_WIDTH } from '@libs/ui/constants';
 import { SidebarMenuItemProps } from '@libs/ui/types/sidebar';
 import { getRootPathName } from '@libs/common/utils';
 import DASHBOARD_ROUTE from '@libs/dashboard/constants/dashboardRoute';
+import NotificationCounter from '@/components/ui/Sidebar/SidebarMenuItems/NotificationCounter';
 import useSidebarStore from '../sidebarStore';
 
 const MobileSidebarItem: React.FC<SidebarMenuItemProps> = ({ menuItem }) => {
@@ -36,6 +37,7 @@ const MobileSidebarItem: React.FC<SidebarMenuItemProps> = ({ menuItem }) => {
         className={`group relative flex cursor-pointer items-center justify-end gap-4 px-4 py-2 md:block md:px-2 ${menuItemColor}`}
       >
         <p className="md:hidden">{menuItem.title}</p>
+
         <img
           src={menuItem.icon}
           width={SIDEBAR_ICON_WIDTH}
@@ -43,6 +45,8 @@ const MobileSidebarItem: React.FC<SidebarMenuItemProps> = ({ menuItem }) => {
           alt={`${menuItem.title}-icon`}
         />
       </NavLink>
+
+      <NotificationCounter count={menuItem.notificationCounter || 0} />
     </div>
   );
 };

--- a/apps/frontend/src/components/ui/Sidebar/SidebarMenuItems/NotificationCounter.tsx
+++ b/apps/frontend/src/components/ui/Sidebar/SidebarMenuItems/NotificationCounter.tsx
@@ -11,25 +11,34 @@
  */
 
 import React from 'react';
-import { FaStarOfLife } from 'react-icons/fa';
 
 interface SidebarItemNotificationProps {
-  notificationCounter?: number;
+  count: number;
+  maxCount?: number;
+  className?: string;
 }
 
-const SidebarItemNotification = (props: SidebarItemNotificationProps) => {
-  const { notificationCounter } = props;
+const NotificationCounter = (props: SidebarItemNotificationProps) => {
+  const { count, maxCount = 9, className } = props;
 
-  if (!notificationCounter || notificationCounter === 0) {
+  if (!count || count === 0) {
     return null;
   }
 
+  const displayCount = count > maxCount ? `${maxCount}+` : `${count}`;
+
   return (
-    <FaStarOfLife
-      size={12}
-      className="absolute right-1 top-1 text-ciLightGreen"
-    />
+    <span
+      className={
+        `absolute right-[10px] top-[2px] inline-flex items-center justify-center ` +
+        `rounded-full bg-ciRed text-xs font-bold text-background ` +
+        `h-5 min-w-[1.25rem] transform px-0 ${className}`
+      }
+      aria-label={`${displayCount} new notifications`}
+    >
+      {displayCount}
+    </span>
   );
 };
 
-export default SidebarItemNotification;
+export default NotificationCounter;

--- a/apps/frontend/src/components/ui/Sidebar/SidebarMenuItems/SidebarItem.tsx
+++ b/apps/frontend/src/components/ui/Sidebar/SidebarMenuItems/SidebarItem.tsx
@@ -15,7 +15,7 @@ import { NavLink, useLocation } from 'react-router-dom';
 import { SIDEBAR_ICON_WIDTH, SIDEBAR_WIDTH } from '@libs/ui/constants';
 import { SidebarMenuItemProps } from '@libs/ui/types/sidebar';
 import { getRootPathName } from '@libs/common/utils';
-import SidebarItemNotification from '@/components/ui/Sidebar/SidebarMenuItems/SidebarItemNotification';
+import NotificationCounter from '@/components/ui/Sidebar/SidebarMenuItems/NotificationCounter';
 import PageTitle from '@/components/PageTitle';
 import useTrulyVisible from '@/hooks/useTrulyVisible';
 import DASHBOARD_ROUTE from '@libs/dashboard/constants/dashboardRoute';
@@ -29,7 +29,7 @@ const SidebarItem: React.FC<SidebarMenuItemProps> = ({
   isUpButtonVisible,
   isDownButtonVisible,
 }) => {
-  const { title, icon, color, link, notificationCounter } = menuItem;
+  const { title, icon, color, link, notificationCounter = 0 } = menuItem;
   const buttonRef = useRef<HTMLDivElement>(null);
   const isTrulyVisible = useTrulyVisible(buttonRef, [translate, isUpButtonVisible, isDownButtonVisible]);
   const { pathname } = useLocation();
@@ -73,7 +73,7 @@ const SidebarItem: React.FC<SidebarMenuItemProps> = ({
         >
           {iconElement}
 
-          <SidebarItemNotification notificationCounter={notificationCounter} />
+          <NotificationCounter count={notificationCounter} />
 
           <div className="-mt-[0.15rem] hidden h-5 text-center md:block">
             <DynamicEllipsis

--- a/apps/frontend/src/components/ui/Sidebar/SidebarMenuItems/index.ts
+++ b/apps/frontend/src/components/ui/Sidebar/SidebarMenuItems/index.ts
@@ -11,7 +11,7 @@
  */
 
 export { default as DownButton } from './DownButton';
-export { default as HomeButton } from './HomeButton';
+export { default as HomeButton } from './LauncherButton';
 export { default as MobileMenuButton } from './MobileMenuButton';
 export { default as MobileSidebarItem } from './MobileSidebarItem';
 export { default as SidebarItem } from './SidebarItem';

--- a/apps/frontend/src/hooks/useModKeyLabel.ts
+++ b/apps/frontend/src/hooks/useModKeyLabel.ts
@@ -13,9 +13,9 @@
 import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
-export default function useModKeyLabel() {
+const useModKeyLabel = () => {
   const { t } = useTranslation();
-  const [label, setLabel] = useState<string>('STRG');
+  const [label, setLabel] = useState<string>(t('ctrlKey'));
 
   useEffect(() => {
     const platform = navigator.platform || navigator.userAgent || '';
@@ -29,4 +29,6 @@ export default function useModKeyLabel() {
   }, []);
 
   return label;
-}
+};
+
+export default useModKeyLabel;

--- a/apps/frontend/src/hooks/useModKeyLabel.ts
+++ b/apps/frontend/src/hooks/useModKeyLabel.ts
@@ -10,18 +10,23 @@
  * You should have received a copy of the GNU Affero General Public License along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
-import React from 'react';
-import { MobileLogoIcon } from '@/assets/icons';
-import { SIDEBAR_ICON_WIDTH } from '@libs/ui/constants';
+import { useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
 
-const HomeButton: React.FC = () => (
-  <div className="group relative right-0 top-0 z-50 flex max-h-14 items-center justify-end gap-4 bg-black px-4 py-2 md:block md:px-3">
-    <img
-      src={MobileLogoIcon}
-      width={SIDEBAR_ICON_WIDTH}
-      alt="edulution-mobile-logo"
-    />
-  </div>
-);
+export default function useModKeyLabel() {
+  const { t } = useTranslation();
+  const [label, setLabel] = useState<string>('STRG');
 
-export default HomeButton;
+  useEffect(() => {
+    const platform = navigator.platform || navigator.userAgent || '';
+    const isMac = /Mac/i.test(platform);
+
+    if (isMac) {
+      setLabel('⌘');
+    } else {
+      setLabel(t('ctrlKey'));
+    }
+  }, []);
+
+  return label;
+}

--- a/apps/frontend/src/hooks/useSidebarItems.ts
+++ b/apps/frontend/src/hooks/useSidebarItems.ts
@@ -24,7 +24,7 @@ import DASHBOARD_ROUTE from '@libs/dashboard/constants/dashboardRoute';
 import getDisplayName from '@/utils/getDisplayName';
 import { SidebarMenuItem } from '@libs/ui/types/sidebar';
 
-export default function useSidebarItems(): SidebarMenuItem[] {
+const useSidebarItems = (): SidebarMenuItem[] => {
   const { t } = useTranslation();
   const { appConfigs } = useAppConfigsStore();
   const { isSuperAdmin } = useLdapGroups();
@@ -72,4 +72,6 @@ export default function useSidebarItems(): SidebarMenuItem[] {
         ]
       : []),
   ];
-}
+};
+
+export default useSidebarItems;

--- a/apps/frontend/src/hooks/useSidebarItems.ts
+++ b/apps/frontend/src/hooks/useSidebarItems.ts
@@ -1,0 +1,75 @@
+/*
+ * LICENSE
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import { useTranslation } from 'react-i18next';
+import APPS from '@libs/appconfig/constants/apps';
+import { Dashboard, SettingsIcon } from '@/assets/icons';
+import useLdapGroups from '@/hooks/useLdapGroups';
+import useLanguage from '@/hooks/useLanguage';
+import useAppConfigsStore from '@/pages/Settings/AppConfig/appConfigsStore';
+import useMailsStore from '@/pages/Mail/useMailsStore';
+import useConferenceStore from '@/pages/ConferencePage/ConferencesStore';
+import useBulletinBoardStore from '@/pages/BulletinBoard/useBulletinBoardStore';
+import { SETTINGS_PATH } from '@libs/appconfig/constants/appConfigPaths';
+import DASHBOARD_ROUTE from '@libs/dashboard/constants/dashboardRoute';
+import getDisplayName from '@/utils/getDisplayName';
+import { SidebarMenuItem } from '@libs/ui/types/sidebar';
+
+export default function useSidebarItems(): SidebarMenuItem[] {
+  const { t } = useTranslation();
+  const { appConfigs } = useAppConfigsStore();
+  const { isSuperAdmin } = useLdapGroups();
+  const { language } = useLanguage();
+
+  const { mails } = useMailsStore();
+  const { runningConferences } = useConferenceStore();
+  const { bulletinBoardNotifications } = useBulletinBoardStore();
+
+  const getNotificationCounter = (app: string): number | undefined => {
+    switch (app) {
+      case APPS.MAIL:
+        return mails.length;
+      case APPS.CONFERENCES:
+        return runningConferences.length;
+      case APPS.BULLETIN_BOARD:
+        return bulletinBoardNotifications.length;
+      default:
+        return undefined;
+    }
+  };
+
+  return [
+    {
+      title: t('dashboard.pageTitle'),
+      link: DASHBOARD_ROUTE,
+      icon: Dashboard,
+      color: 'bg-ciGreenToBlue',
+    },
+    ...appConfigs.map((cfg) => ({
+      title: getDisplayName(cfg, language),
+      link: `/${cfg.name}`,
+      icon: cfg.icon,
+      color: 'bg-ciGreenToBlue',
+      notificationCounter: getNotificationCounter(cfg.name),
+    })),
+    ...(isSuperAdmin
+      ? [
+          {
+            title: t('settings.sidebar'),
+            link: `/${SETTINGS_PATH}`,
+            icon: SettingsIcon,
+            color: 'bg-ciGreenToBlue',
+          },
+        ]
+      : []),
+  ];
+}

--- a/apps/frontend/src/hooks/useTrulyVisible.ts
+++ b/apps/frontend/src/hooks/useTrulyVisible.ts
@@ -69,11 +69,15 @@ const useTrulyVisible = (
     };
 
     check();
+
+    const raf = window.requestAnimationFrame(check);
+
     window.addEventListener('scroll', check, true);
     window.addEventListener('resize', check);
 
     // eslint-disable-next-line consistent-return
     return () => {
+      window.cancelAnimationFrame(raf);
       window.removeEventListener('scroll', check, true);
       window.removeEventListener('resize', check);
     };

--- a/apps/frontend/src/locales/de/translation.json
+++ b/apps/frontend/src/locales/de/translation.json
@@ -761,7 +761,15 @@
     "yourPassword": "Dein Passwort",
     "addButton": "Hinzufügen"
   },
-
+  "ctrlKey": "STRG",
+  "enterKey": "Enter",
+  "launcher": {
+    "title": "App Launcher",
+    "searchApps": "Tippen um Apps zu filtern...",
+    "pressShortKey": "Launcher öffnen mit",
+    "pressEnterToStartApp": "Erste App öffnen mit",
+    "noSearchResults": "Keine Ergebnisse für diese Sucheingabe"
+  },
   "settings": {
     "title": "EINSTELLUNGEN",
     "sidebar": "Einstellungen",

--- a/apps/frontend/src/locales/de/translation.json
+++ b/apps/frontend/src/locales/de/translation.json
@@ -768,7 +768,7 @@
     "searchApps": "Tippen um Apps zu filtern...",
     "pressShortKey": "Launcher öffnen mit",
     "pressEnterToStartApp": "Erste App öffnen mit",
-    "noSearchResults": "Keine Ergebnisse für diese Sucheingabe"
+    "noSearchResults": "Keine App gefunden"
   },
   "settings": {
     "title": "EINSTELLUNGEN",

--- a/apps/frontend/src/locales/en/translation.json
+++ b/apps/frontend/src/locales/en/translation.json
@@ -758,6 +758,15 @@
     "yourPassword": "Your Password",
     "addButton": "Add"
   },
+  "ctrlKey": "Ctrl",
+  "enterKey": "Enter",
+  "launcher": {
+    "title": "App Launcher",
+    "searchApps": "Type to filter apps...",
+    "pressShortKey": "To open launcher press",
+    "pressEnterToStartApp": "To launch first app press",
+    "noSearchResults": "No results for your search term"
+  },
   "settings": {
     "title": "SETTINGS",
     "sidebar": "Settings",

--- a/apps/frontend/src/locales/en/translation.json
+++ b/apps/frontend/src/locales/en/translation.json
@@ -765,7 +765,7 @@
     "searchApps": "Type to filter apps...",
     "pressShortKey": "To open launcher press",
     "pressEnterToStartApp": "To launch first app press",
-    "noSearchResults": "No results for your search term"
+    "noSearchResults": "No app found"
   },
   "settings": {
     "title": "SETTINGS",

--- a/apps/frontend/src/store/utils/cleanAllStores.ts
+++ b/apps/frontend/src/store/utils/cleanAllStores.ts
@@ -44,6 +44,7 @@ import useFileSharingDownloadStore from '@/pages/FileSharing/useFileSharingDownl
 import useEduApiStore from '@/store/EduApiStore/useEduApiStore';
 import TLDRAW_PERSISTENCE_KEY from '@libs/whiteboard/constants/tldrawPersistenceKey';
 import clearTLDrawPersistence from '@/pages/Whiteboard/clearTLDrawPersitence';
+import useLauncherStore from '@/components/ui/Launcher/useLauncherStore';
 import useSseStore from '../useSseStore';
 
 const cleanAllStores = async () => {
@@ -67,6 +68,7 @@ const cleanAllStores = async () => {
   useFileSharingStore.getState().reset();
   useFileSharingDownloadStore.getState().reset();
   useFrameStore.getState().reset();
+  useLauncherStore.getState().reset();
   useLessonStore.getState().reset();
   useLmnApiPasswordStore.getState().reset();
   useLmnApiStore.getState().reset();

--- a/libs/src/common/utils/string/isSubsequence.ts
+++ b/libs/src/common/utils/string/isSubsequence.ts
@@ -10,8 +10,17 @@
  * You should have received a copy of the GNU Affero General Public License along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
-export const INPUT_VARIANT_DEFAULT = 'bg-accent text-secondary placeholder:text-p focus:outline-none';
-export const INPUT_VARIANT_DIALOG = 'bg-muted placeholder:text-p focus:outline-none text-background';
+const isSubsequence = (needle: string, haystack: string): boolean => {
+  let i = 0;
+  let j = 0;
 
-export const INPUT_DEFAULT =
-  'flex h-9 rounded-md px-3 py-1 text-p text-background shadow-sm transition-colors file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50';
+  while (i < needle.length && j < haystack.length) {
+    if (needle[i] === haystack[j]) i += 1;
+
+    j += 1;
+  }
+
+  return i === needle.length;
+};
+
+export default isSubsequence;

--- a/libs/src/ui/constants/launcherSearchInputLabel.ts
+++ b/libs/src/ui/constants/launcherSearchInputLabel.ts
@@ -10,18 +10,6 @@
  * You should have received a copy of the GNU Affero General Public License along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
-const isSubsequence = (pattern: string, text: string): boolean => {
-  let patternIndex = 0;
-  let textIndex = 0;
+const SEARCH_INPUT_LABEL = 'launcher.searchApps';
 
-  while (patternIndex < pattern.length && textIndex < text.length) {
-    if (pattern[patternIndex] === text[textIndex]) {
-      patternIndex += 1;
-    }
-    textIndex += 1;
-  }
-
-  return patternIndex === pattern.length;
-};
-
-export default isSubsequence;
+export default SEARCH_INPUT_LABEL;


### PR DESCRIPTION
- Add an app launcher that can be opened by clicking on the edulution logo or with CTRL/CMD + K
- Display apps in a grid in the launcher
- Make the apps filterable and launch the first app in the list with enter
- Also for mobile view
- Add new hook to determine the CTRL (windows, linux) or CMD key (mac) `useModKeyLabel`
- Add new hook to make the sidebar entries available `useSidebarItems`