### PR TITLE
974 - Auth - Fix logout with silent redirect error

### DIFF
--- a/apps/frontend/src/hooks/useLogout.tsx
+++ b/apps/frontend/src/hooks/useLogout.tsx
@@ -36,9 +36,11 @@ const useLogout = () => {
     if (auth.user?.expired) {
       toast.error(t('auth.errors.TokenExpired'));
     } else {
-      toast.success(t('auth.logout.success'));
+      toast.success(t('auth.logout.success'), {
+        id: 'logout-success',
+      });
     }
-  }, [logout, auth]);
+  }, [auth]);
 
   return handleLogout;
 };

--- a/apps/frontend/src/pages/LoginPage/LoginPage.tsx
+++ b/apps/frontend/src/pages/LoginPage/LoginPage.tsx
@@ -79,6 +79,10 @@ const LoginPage: React.FC = () => {
         form.setError('password', { message: t('auth.errors.EdulutionConnectionFailed') });
         return;
       }
+      if (auth.error.source.includes('renewSilent')) {
+        form.setError('password', { message: t('auth.errors.TokenExpired') });
+        return;
+      }
       form.setError('password', { message: t(auth.error.message) });
 
       if (showQrCode) {


### PR DESCRIPTION
- Reworked auth event listeners to only be mounted once
- Add toast to warn if renew failed instead of logout instantly