### PR TITLE
Reload UI if the version changes

### DIFF
--- a/.idea/easy-i18n.xml
+++ b/.idea/easy-i18n.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectSettingsService">
+    <option name="localesDirectory" value="" />
+    <option name="defaultNamespace" value="" />
+  </component>
+</project>

--- a/.idea/edulution-ui-si.iml
+++ b/.idea/edulution-ui-si.iml
@@ -5,6 +5,11 @@
       <excludeFolder url="file://$MODULE_DIR$/.tmp" />
       <excludeFolder url="file://$MODULE_DIR$/temp" />
       <excludeFolder url="file://$MODULE_DIR$/tmp" />
+      <excludeFolder url="file://$MODULE_DIR$/coverage" />
+      <excludeFolder url="file://$MODULE_DIR$/data" />
+      <excludeFolder url="file://$MODULE_DIR$/dist" />
+      <excludeFolder url="file://$MODULE_DIR$/docs" />
+      <excludeFolder url="file://$MODULE_DIR$/traefik" />
     </content>
     <orderEntry type="inheritedJdk" />
     <orderEntry type="sourceFolder" forTests="false" />

--- a/apps/api/src/main.ts
+++ b/apps/api/src/main.ts
@@ -23,6 +23,7 @@ import { WsAdapter } from '@nestjs/platform-ws';
 import AppModule from './app/app.module';
 import AuthGuard from './auth/auth.guard';
 import getLogLevels from './logging/getLogLevels';
+import * as rootPackage from '../../../package.json';
 
 async function bootstrap() {
   const globalPrefix = EDU_API_ROOT;
@@ -74,6 +75,7 @@ async function bootstrap() {
   await app.listen(port);
   if (logLevels) {
     Logger.log(`🚀 Application is running on: http://localhost:${port}/${globalPrefix}`);
+    Logger.debug(`Application Version: ${rootPackage.version}`);
     Logger.log(`Logging-Levels: ${logLevels.map((level) => level.toUpperCase()).join(', ')}`);
   } else {
     console.info(`Application is running on: http://localhost:${port}/${globalPrefix}`);

--- a/apps/api/src/main.ts
+++ b/apps/api/src/main.ts
@@ -74,8 +74,7 @@ async function bootstrap() {
 
   await app.listen(port);
   if (logLevels) {
-    Logger.log(`🚀 Application is running on: http://localhost:${port}/${globalPrefix}`);
-    Logger.debug(`Application Version: ${rootPackage.version}`);
+    Logger.log(`🚀 Application Version ${rootPackage.version} is running on: http://localhost:${port}/${globalPrefix}`);
     Logger.log(`Logging-Levels: ${logLevels.map((level) => level.toUpperCase()).join(', ')}`);
   } else {
     console.info(`Application is running on: http://localhost:${port}/${globalPrefix}`);

--- a/apps/api/src/sse/sse.service.ts
+++ b/apps/api/src/sse/sse.service.ts
@@ -17,6 +17,7 @@ import { Response } from 'express';
 import { Interval } from '@nestjs/schedule';
 import SSE_MESSAGE_TYPE from '@libs/common/constants/sseMessageType';
 import type SseStatus from '@libs/common/types/sseMessageType';
+import * as rootPackage from '../../../../package.json';
 import type UserConnections from '../types/userConnections';
 import type SseEvent from '../types/sseEvent';
 import type SseEventData from '../types/sseEventData';
@@ -30,6 +31,7 @@ class SseService {
     this.informAllUsers(
       JSON.stringify({
         timestamp: new Date().toISOString(),
+        version: rootPackage.version,
       }),
       SSE_MESSAGE_TYPE.PING,
     );

--- a/apps/api/tsconfig.app.json
+++ b/apps/api/tsconfig.app.json
@@ -11,5 +11,5 @@
     "declaration": true
   },
   "exclude": ["src/**/*.spec.ts", "src/**/*.test.ts"],
-  "include": ["./**/*", "../../libs/**/*"]
+  "include": ["./**/*", "../../libs/**/*", "../../package.json"]
 }

--- a/apps/frontend/src/components/GlobalHooksWrapper.tsx
+++ b/apps/frontend/src/components/GlobalHooksWrapper.tsx
@@ -21,6 +21,7 @@ import isDev from '@libs/common/constants/isDev';
 import DASHBOARD_ROUTE from '@libs/dashboard/constants/dashboardRoute';
 import useGlobalSettingsApiStore from '@/pages/Settings/GlobalSettings/useGlobalSettingsApiStore';
 import COOKIE_DESCRIPTORS from '@libs/common/constants/cookieDescriptors';
+import useVersionChecker from '@/hooks/useVersionChecker';
 import useAppConfigsStore from '../pages/Settings/AppConfig/appConfigsStore';
 import useUserStore from '../store/UserStore/useUserStore';
 import useLogout from '../hooks/useLogout';
@@ -61,6 +62,8 @@ const GlobalHooksWrapper: React.FC<{ children: React.ReactNode }> = ({ children 
   }, [eduApiToken]);
 
   useNotifications();
+
+  useVersionChecker();
 
   useEffect(() => {
     const getInitialAppData = async () => {

--- a/apps/frontend/src/components/ui/Toaster.tsx
+++ b/apps/frontend/src/components/ui/Toaster.tsx
@@ -29,7 +29,7 @@ const Toaster = ({ ...props }: ToasterProps) => (
       duration: SHOW_TOASTER_DURATION,
       classNames: {
         toast: 'group toast group-[.toaster]:bg-overlay group-[.toaster]:border-border group-[.toaster]:shadow-lg',
-        content: 'group-[.toaster]:text-background',
+        content: 'whitespace-pre-line group-[.toaster]:text-background',
       },
     }}
     richColors

--- a/apps/frontend/src/hooks/useVersionChecker.tsx
+++ b/apps/frontend/src/hooks/useVersionChecker.tsx
@@ -1,0 +1,71 @@
+/*
+ * LICENSE
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import React, { useEffect, useRef, useState } from 'react';
+import { toast } from 'sonner';
+import useSseStore from '@/store/useSseStore';
+import SSE_MESSAGE_TYPE from '@libs/common/constants/sseMessageType';
+import { GrUpgrade } from 'react-icons/gr';
+import { useTranslation } from 'react-i18next';
+import APPLICATION_NAME from '@libs/common/constants/applicationName';
+
+const useVersionChecker = () => {
+  const currentVersion = useRef<string>(String(APP_VERSION));
+  const [hasNewVersion, setHasNewVersion] = useState(false);
+  const { eventSource } = useSseStore();
+  const { t } = useTranslation();
+
+  useEffect(() => {
+    if (!eventSource) {
+      return undefined;
+    }
+
+    const controller = new AbortController();
+    const { signal } = controller;
+
+    const handleNewVersion = (event: MessageEvent) => {
+      try {
+        const { version } = JSON.parse((event as { data: string }).data) as { version: string };
+
+        if (version !== currentVersion.current) {
+          setHasNewVersion(true);
+        }
+      } catch {
+        console.error('Error setting new version');
+      }
+    };
+
+    eventSource.addEventListener(SSE_MESSAGE_TYPE.PING, handleNewVersion, { signal });
+
+    return () => {
+      controller.abort();
+      setHasNewVersion(false);
+    };
+  }, [eventSource]);
+
+  useEffect(() => {
+    if (hasNewVersion) {
+      toast(t('version.newVersionAvailable', { appName: APPLICATION_NAME }), {
+        duration: Infinity,
+        position: 'top-center',
+        icon: <GrUpgrade />,
+        action: {
+          label: t('version.update'),
+          onClick: () => window.location.reload(),
+        },
+        onDismiss: () => setHasNewVersion(false),
+      });
+    }
+  }, [hasNewVersion]);
+};
+
+export default useVersionChecker;

--- a/apps/frontend/src/hooks/useVersionChecker.tsx
+++ b/apps/frontend/src/hooks/useVersionChecker.tsx
@@ -54,11 +54,11 @@ const useVersionChecker = () => {
 
   useEffect(() => {
     if (hasNewVersion) {
-      toast(t('version.newVersionAvailable', { appName: APPLICATION_NAME }), {
+      toast.info(t('version.newVersionAvailable', { appName: APPLICATION_NAME }), {
         id: `version-${currentVersion.current}`,
         duration: Infinity,
-        position: 'top-center',
-        icon: <GrUpgrade />,
+        position: 'top-right',
+        icon: <GrUpgrade color="green" />,
         action: {
           label: t('version.update'),
           onClick: () => window.location.reload(),

--- a/apps/frontend/src/hooks/useVersionChecker.tsx
+++ b/apps/frontend/src/hooks/useVersionChecker.tsx
@@ -55,7 +55,7 @@ const useVersionChecker = () => {
   useEffect(() => {
     if (hasNewVersion) {
       toast(t('version.newVersionAvailable', { appName: APPLICATION_NAME }), {
-        id: `version-${currentVersion}`,
+        id: `version-${currentVersion.current}`,
         duration: Infinity,
         position: 'top-center',
         icon: <GrUpgrade />,

--- a/apps/frontend/src/hooks/useVersionChecker.tsx
+++ b/apps/frontend/src/hooks/useVersionChecker.tsx
@@ -55,6 +55,7 @@ const useVersionChecker = () => {
   useEffect(() => {
     if (hasNewVersion) {
       toast(t('version.newVersionAvailable', { appName: APPLICATION_NAME }), {
+        id: `version-${currentVersion}`,
         duration: Infinity,
         position: 'top-center',
         icon: <GrUpgrade />,

--- a/apps/frontend/src/locales/de/translation.json
+++ b/apps/frontend/src/locales/de/translation.json
@@ -1600,7 +1600,7 @@
     }
   },
   "version": {
-    "newVersionAvailable": "Es ist eine neue Version von {{ appName }} verfügbar.\n\nKlicke auf \"Aktualisieren\" um die Seite im Browser neu zu laden und Probleme zu vermeiden.\n\nUngespeicherte Änderungen können verloren gehen.",
+    "newVersionAvailable": "Es ist eine neue Version von {{ appName }} verfügbar.",
     "update": "Aktualisieren"
   },
   "veyon": {

--- a/apps/frontend/src/locales/de/translation.json
+++ b/apps/frontend/src/locales/de/translation.json
@@ -1599,6 +1599,10 @@
       "dead": "tot"
     }
   },
+  "version": {
+    "newVersionAvailable": "Es ist eine neue Version von {{ appName }} verfügbar.\n\nKlicke auf \"Aktualisieren\" um die Seite im Browser neu zu laden und Probleme zu vermeiden.\n\nUngespeicherte Änderungen können verloren gehen.",
+    "update": "Aktualisieren"
+  },
   "veyon": {
     "lockScreen": "Bildschirm sperren",
     "unlockScreen": "Bildschirm entsprerren",

--- a/apps/frontend/src/locales/en/translation.json
+++ b/apps/frontend/src/locales/en/translation.json
@@ -1595,6 +1595,10 @@
       "dead": "dead"
     }
   },
+  "version": {
+    "newVersionAvailable": "A new version of {{ appName }} is available.\n\nClick on “Refresh” to reload the page in the browser and avoid problems.\n\nUnsaved changes may be lost.",
+    "update": "Refresh"
+  },
   "veyon": {
     "lockScreen": "Lock screen",
     "unlockScreen": "Unlock screen",

--- a/apps/frontend/src/locales/en/translation.json
+++ b/apps/frontend/src/locales/en/translation.json
@@ -1596,7 +1596,7 @@
     }
   },
   "version": {
-    "newVersionAvailable": "A new version of {{ appName }} is available.\n\nClick on “Refresh” to reload the page in the browser and avoid problems.\n\nUnsaved changes may be lost.",
+    "newVersionAvailable": "A new version of {{ appName }} is available.",
     "update": "Refresh"
   },
   "veyon": {


### PR DESCRIPTION
Add toaster to refresh the page:
![grafik](https://github.com/user-attachments/assets/b4d27e0b-96e8-475e-ac41-442ee3b41993)
- Allow dismissing of the toaster, but show it again

- Also log the version number in the backend
- Enable line-breaks with `\n` in toasters