### PR TITLE
1087 filesharing enable file upload for unlimited file sizes

### DIFF
--- a/apps/api/src/filesharing/filesharing.controller.ts
+++ b/apps/api/src/filesharing/filesharing.controller.ts
@@ -44,6 +44,7 @@ import CreateOrEditPublicShareDto from '@libs/filesharing/types/createOrEditPubl
 import PublicShareDto from '@libs/filesharing/types/publicShareDto';
 import UploadFileDto from '@libs/filesharing/types/uploadFileDto';
 import JWTUser from '@libs/user/types/jwt/jwtUser';
+import { diskStorage } from 'multer';
 import GetCurrentUsername from '../common/decorators/getCurrentUsername.decorator';
 import FilesystemService from '../filesystem/filesystem.service';
 import FilesharingService from './filesharing.service';
@@ -92,7 +93,16 @@ class FilesharingController {
   }
 
   @Post(FileSharingApiEndpoints.UPLOAD)
-  @UseInterceptors(FileInterceptor('file'))
+  @UseInterceptors(
+    FileInterceptor('uploadedFile', {
+      storage: diskStorage({
+        destination: './temp/file-uploads',
+        filename: (_request, incomingFile, done) => {
+          done(null, incomingFile.originalname);
+        },
+      }),
+    }),
+  )
   async uploadFile(
     @UploadedFile() file: CustomFile,
     @Query('path') path: string,

--- a/apps/api/src/filesharing/filesharing.service.ts
+++ b/apps/api/src/filesharing/filesharing.service.ts
@@ -120,6 +120,7 @@ class FilesharingService {
         await this.dynamicQueueService.addJobForUser(username, JOB_NAMES.FILE_UPLOAD_JOB, {
           username,
           fullPath: `${parentPath}/${folderName}/${entry.path}`,
+          path: entry.path,
           file: {
             fieldname: 'file',
             originalname: fileName,

--- a/libs/src/ui/constants/maxFileUploadSize.ts
+++ b/libs/src/ui/constants/maxFileUploadSize.ts
@@ -10,5 +10,5 @@
  * You should have received a copy of the GNU Affero General Public License along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
-const MAX_FILE_UPLOAD_SIZE = 50; // MB
+const MAX_FILE_UPLOAD_SIZE = 500; // MB
 export default MAX_FILE_UPLOAD_SIZE;


### PR DESCRIPTION
- Enabled file up-streaming to resolve the issue caused by the maximum buffer size of node, which results in the backend failing.
- Increased file limit to 400 MB. The WebDAV endpoint cannot handle more than 400–500 MB without failing (The CPU consumption increased to 100% on all four cores)