### PR TITLE
1141 - Participation shows 0 even after a user has participated

### DIFF
--- a/apps/api/src/surveys/survey-answers.service.ts
+++ b/apps/api/src/surveys/survey-answers.service.ts
@@ -323,6 +323,11 @@ class SurveyAnswersService implements OnModuleInit {
       updatedAnswer,
     );
     void this.surveyAnswerAttachmentsService.clearUpSurveyAnswersTempFiles(username, String(survey.id));
+
+    if (createdAnswer) {
+      await this.updateSurveyParticipations(survey, String(createdAnswer.id), username);
+    }
+
     return createdAnswer;
   }
 
@@ -356,10 +361,10 @@ class SurveyAnswersService implements OnModuleInit {
       survey.saveNo,
       updatedAnswer,
     );
-    void this.surveyAnswerAttachmentsService.clearUpSurveyAnswersTempFiles(firstName, String(survey.id));
+    void this.surveyAnswerAttachmentsService.clearUpSurveyAnswersTempFiles(user.username, String(survey.id));
 
     if (createdAnswer) {
-      await this.updateSurveyParticipations(survey, String(createdAnswer.id), firstName);
+      await this.updateSurveyParticipations(survey, String(createdAnswer.id), user.username);
     }
 
     return createdAnswer;

--- a/apps/api/src/surveys/survey-answers.service.ts
+++ b/apps/api/src/surveys/survey-answers.service.ts
@@ -309,7 +309,7 @@ class SurveyAnswersService implements OnModuleInit {
   };
 
   async anonymousStrategy(survey: SurveyDocument, answer: JSON): Promise<SurveyAnswerDocument | null> {
-    const username = 'anonymous';
+    const username = `anonymous_${uuidv4()}`;
     const user: Attendee = { username };
     const updatedAnswer = await this.surveyAnswerAttachmentsService.moveAnswersAttachmentsToPermanentStorage(
       username,


### PR DESCRIPTION
It is possible that this is nearly fixed by 833-survey-participation-add-custom-file-upload-for-questions-file-type-rebased (https://github.com/edulution-io/edulution-ui/pull/1016)

Issue: https://github.com/edulution-io/edulution-ui/issues/1141

1141:
* make sure that updateSurveyParticipations gets executed in every none updating answer strategy