### PR TITLE
1142 - Survey - Write a migration to write templates to the db

### DIFF
--- a/apps/api/src/filesystem/filesystem.service.ts
+++ b/apps/api/src/filesystem/filesystem.service.ts
@@ -104,6 +104,20 @@ class FilesystemService {
     }
   }
 
+  static async readFile<T>(filePath: string): Promise<T> {
+    try {
+      const fileContent = await readFile(filePath, 'utf-8');
+      return JSON.parse(fileContent) as T;
+    } catch (error) {
+      throw new CustomHttpException(
+        CommonErrorMessages.FILE_READING_FAILED,
+        HttpStatus.INTERNAL_SERVER_ERROR,
+        filePath,
+        FilesystemService.name,
+      );
+    }
+  }
+
   static async moveFile(oldFilePath: string, newFilePath: string): Promise<void> {
     try {
       await move(oldFilePath, newFilePath, { overwrite: true });

--- a/apps/api/src/surveys/surveys-template.schema.ts
+++ b/apps/api/src/surveys/surveys-template.schema.ts
@@ -1,0 +1,38 @@
+/*
+ * LICENSE
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import { Document } from 'mongoose';
+import { Prop, Schema, SchemaFactory } from '@nestjs/mongoose';
+import SurveyFormula from '@libs/survey/types/SurveyFormula';
+import { Survey } from './survey.schema';
+
+export type SurveysTemplateDocument = SurveysTemplate & Document;
+
+@Schema({ timestamps: true, strict: true })
+export class SurveysTemplate {
+  @Prop({ type: Object, required: true })
+  template: Partial<Survey> & { formula: SurveyFormula };
+
+  @Prop({ required: true })
+  fileName: string;
+
+  @Prop({ default: true, required: true })
+  isActive: boolean;
+}
+
+const SurveysTemplateSchema = SchemaFactory.createForClass(SurveysTemplate);
+
+SurveysTemplateSchema.set('toJSON', {
+  virtuals: true,
+});
+
+export default SurveysTemplateSchema;

--- a/apps/api/src/surveys/surveys-template.service.ts
+++ b/apps/api/src/surveys/surveys-template.service.ts
@@ -13,11 +13,13 @@
 import { join } from 'path';
 import { Response } from 'express';
 import { v4 as uuidv4 } from 'uuid';
-import { HttpStatus, Injectable } from '@nestjs/common';
-import SurveyTemplateDto from '@libs/survey/types/api/template.dto';
+import { InjectModel } from '@nestjs/mongoose';
+import { HttpStatus, Injectable, OnModuleInit } from '@nestjs/common';
 import CommonErrorMessages from '@libs/common/constants/common-error-messages';
 import getCurrentDateTimeString from '@libs/common/utils/Date/getCurrentDateTimeString';
 import SURVEYS_TEMPLATE_PATH from '@libs/survey/constants/surveysTemplatePath';
+import { SurveyTemplateDto, TemplateDto } from '@libs/survey/types/api/surveyTemplate.dto';
+import { SurveysTemplate, SurveysTemplateDocument } from 'apps/api/src/surveys/surveys-template.schema';
 import CustomHttpException from '../common/CustomHttpException';
 import FilesystemService from '../filesystem/filesystem.service';
 

--- a/apps/api/src/surveys/surveys.controller.spec.ts
+++ b/apps/api/src/surveys/surveys.controller.spec.ts
@@ -60,6 +60,7 @@ import mockFilesystemService from '../filesystem/filesystem.service.mock';
 import SurveysAttachmentService from './surveys-attachment.service';
 import SurveysTemplateService from './surveys-template.service';
 import NotificationsService from '../notifications/notifications.service';
+import { SurveysTemplate } from './surveys-template.schema';
 
 describe(SurveysController.name, () => {
   let controller: SurveysController;
@@ -88,6 +89,17 @@ describe(SurveysController.name, () => {
             find: jest.fn().mockReturnThis(),
             sort: jest.fn().mockReturnThis(),
             limit: jest.fn().mockResolvedValueOnce([firstUsersSurveyAnswerAnsweredSurvey01]),
+          },
+        },
+        {
+          provide: getModelToken(SurveysTemplate.name),
+          useValue: {
+            find: jest.fn().mockReturnThis(),
+            findOne: jest.fn().mockReturnThis(),
+            findOneAndUpdate: jest.fn().mockReturnThis(),
+            findById: jest.fn().mockReturnThis(),
+            findByIdAndUpdate: jest.fn().mockReturnThis(),
+            create: jest.fn().mockReturnThis(),
           },
         },
         { provide: FilesystemService, useValue: mockFilesystemService },

--- a/apps/api/src/surveys/surveys.controller.ts
+++ b/apps/api/src/surveys/surveys.controller.ts
@@ -43,7 +43,7 @@ import {
 import SURVEYS_TEMP_FILES_PATH from '@libs/survey/constants/surveysTempFilesPath';
 import SurveyStatus from '@libs/survey/survey-status-enum';
 import SurveyDto from '@libs/survey/types/api/survey.dto';
-import SurveyTemplateDto from '@libs/survey/types/api/template.dto';
+import { SurveyTemplateDto } from '@libs/survey/types/api/surveyTemplate.dto';
 import PostSurveyAnswerDto from '@libs/survey/types/api/post-survey-answer.dto';
 import DeleteSurveyDto from '@libs/survey/types/api/delete-survey.dto';
 import { HTTP_HEADERS, RequestResponseContentType } from '@libs/common/types/http-methods';
@@ -118,7 +118,7 @@ class SurveysController {
   @UseGuards(AppConfigGuard)
   @Post(TEMPLATES)
   async createTemplate(@Body() surveyTemplateDto: SurveyTemplateDto) {
-    return this.surveysTemplateService.createTemplate(surveyTemplateDto);
+    return this.surveysTemplateService.createTemplateDocument(surveyTemplateDto);
   }
 
   @Get(TEMPLATES)

--- a/apps/api/src/surveys/surveys.module.ts
+++ b/apps/api/src/surveys/surveys.module.ts
@@ -14,6 +14,7 @@ import { Module } from '@nestjs/common';
 import { MongooseModule } from '@nestjs/mongoose';
 import SurveySchema, { Survey } from './survey.schema';
 import SurveyAnswerSchema, { SurveyAnswer } from './survey-answer.schema';
+import SurveysTemplateSchema, { SurveysTemplate } from 'apps/api/src/surveys/surveys-template.schema';
 import SurveysService from './surveys.service';
 import SurveysController from './surveys.controller';
 import SurveyAnswerService from './survey-answer.service';
@@ -26,6 +27,7 @@ import SurveysTemplateService from './surveys-template.service';
   imports: [
     MongooseModule.forFeature([{ name: Survey.name, schema: SurveySchema }]),
     MongooseModule.forFeature([{ name: SurveyAnswer.name, schema: SurveyAnswerSchema }]),
+    MongooseModule.forFeature([{ name: SurveysTemplate.name, schema: SurveysTemplateSchema }]),
     GroupsModule,
   ],
   controllers: [SurveysController, PublicSurveysController],

--- a/apps/api/src/surveys/surveys.module.ts
+++ b/apps/api/src/surveys/surveys.module.ts
@@ -12,9 +12,9 @@
 
 import { Module } from '@nestjs/common';
 import { MongooseModule } from '@nestjs/mongoose';
+import SurveysTemplateSchema, { SurveysTemplate } from 'apps/api/src/surveys/surveys-template.schema';
 import SurveySchema, { Survey } from './survey.schema';
 import SurveyAnswerSchema, { SurveyAnswer } from './survey-answer.schema';
-import SurveysTemplateSchema, { SurveysTemplate } from 'apps/api/src/surveys/surveys-template.schema';
 import SurveysService from './surveys.service';
 import SurveysController from './surveys.controller';
 import SurveyAnswerService from './survey-answer.service';

--- a/apps/frontend/src/locales/de/translation.json
+++ b/apps/frontend/src/locales/de/translation.json
@@ -1177,6 +1177,7 @@
       "fileUploadFailed": "Die Datei konnte nicht hochgeladen werden",
       "fileDeletionFailed": "Löschen der Datei fehlgeschlagen",
       "fileWritingFailed": "Schreiben der Datei fehlgeschlagen",
+      "fileReadingFailed": "Datei konnte nicht gelesen werden",
       "fileMoveFailed": "Verschieben der Datei fehlgeschlagen",
       "fileNotFound": "Datei nicht gefunden",
       "fileNotProvided": "Datei wurde nicht bereitgestellt",

--- a/apps/frontend/src/locales/en/translation.json
+++ b/apps/frontend/src/locales/en/translation.json
@@ -1174,6 +1174,7 @@
       "fileUploadFailed": "Failed to upload the file",
       "fileDeletionFailed": "Failed to delete the file",
       "fileWritingFailed": "Failed to write the file",
+      "fileReadingFailed": "Reading file failed",
       "fileMoveFailed": "Failed to move the file",
       "fileNotFound": "File not found",
       "fileNotProvided": "File not provided",

--- a/apps/frontend/src/pages/Surveys/Editor/SurveyEditorPage.tsx
+++ b/apps/frontend/src/pages/Surveys/Editor/SurveyEditorPage.tsx
@@ -26,7 +26,7 @@ import AttendeeDto from '@libs/user/types/attendee.dto';
 import SurveyFormula from '@libs/survey/types/SurveyFormula';
 import getInitialSurveyFormValues from '@libs/survey/constants/initial-survey-form';
 import { CREATED_SURVEYS_PAGE } from '@libs/survey/constants/surveys-endpoint';
-import getSurveyEditorFormSchema from '@libs/survey/types/editor/surveyEditorForm.schema';
+import getSurveyEditorFormSchema from '@libs/survey/types/editor/getSurveyEditorForm.schema';
 import useUserStore from '@/store/UserStore/useUserStore';
 import useSurveyTablesPageStore from '@/pages/Surveys/Tables/useSurveysTablesPageStore';
 import useSurveyEditorPageStore from '@/pages/Surveys/Editor/useSurveyEditorPageStore';

--- a/libs/src/common/constants/common-error-messages.ts
+++ b/libs/src/common/constants/common-error-messages.ts
@@ -16,6 +16,7 @@ enum CommonErrorMessages {
   FILE_UPLOAD_FAILED = 'common.errors.fileUploadFailed',
   FILE_DELETION_FAILED = 'common.errors.fileDeletionFailed',
   FILE_WRITING_FAILED = 'common.errors.fileWritingFailed',
+  FILE_READING_FAILED = 'common.errors.fileReadingFailed',
   FILE_MOVE_FAILED = 'common.errors.fileMoveFailed',
   FILE_NOT_FOUND = 'common.errors.fileNotFound',
   FILE_NOT_PROVIDED = 'common.errors.fileNotProvided',

--- a/libs/src/survey/types/api/surveyTemplate.dto.ts
+++ b/libs/src/survey/types/api/surveyTemplate.dto.ts
@@ -1,0 +1,21 @@
+/*
+ * LICENSE
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import SurveyFormula from '@libs/survey/types/SurveyFormula';
+import SurveyDto from './survey.dto';
+
+export type TemplateDto = Partial<SurveyDto> & { formula: SurveyFormula };
+
+export interface SurveyTemplateDto {
+  template: TemplateDto;
+  fileName?: string;
+}

--- a/libs/src/survey/types/editor/getSurveyEditorForm.schema.ts
+++ b/libs/src/survey/types/editor/getSurveyEditorForm.schema.ts
@@ -1,0 +1,109 @@
+/*
+ * LICENSE
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import { z } from 'zod';
+
+const getSurveyEditorFormSchema = () => z.object({
+  id: z.number(),
+  formula: z.object({
+    title: z.string(),
+    description: z.string().optional(),
+    pages: z.array(
+      z.object({
+        name: z.string(),
+        description: z.string().optional(),
+        elements: z.array(
+          z.object({
+            type: z.string(),
+            name: z.string(),
+            description: z.string().optional(),
+            isRequired: z.boolean().optional(),
+            choices: z
+              .array(
+                z.object({
+                  value: z.string(),
+                  label: z.string(),
+                }),
+              )
+              .optional(),
+            choicesByUrl: z
+              .object({
+                url: z.string(),
+              })
+              .optional(),
+          }),
+        ),
+      }),
+    ),
+  }),
+  backendLimiters: z
+    .array(
+      z.object({
+        questionName: z.string().optional(),
+        choices: z.array(
+          z.object({
+            name: z.string().optional(),
+            title: z.string().optional(),
+            limit: z.number().optional(),
+          }),
+        ),
+      }),
+    )
+    .optional(),
+  saveNo: z.number().optional(),
+  creator: z.intersection(
+    z.object({
+      firstName: z.string().optional(),
+      lastName: z.string().optional(),
+      username: z.string(),
+    }),
+    z.object({
+      value: z.string(),
+      label: z.string(),
+    }),
+  ),
+  invitedAttendees: z.array(
+    z.intersection(
+      z.object({
+        firstName: z.string().optional(),
+        lastName: z.string().optional(),
+        username: z.string(),
+      }),
+      z.object({
+        value: z.string(),
+        label: z.string(),
+      }),
+    ),
+  ),
+  invitedGroups: z.array(z.object({})),
+  participatedAttendees: z.array(
+    z.intersection(
+      z.object({
+        firstName: z.string().optional(),
+        lastName: z.string().optional(),
+        username: z.string(),
+      }),
+      z.object({
+        value: z.string(),
+        label: z.string(),
+      }),
+    ),
+  ),
+  answers: z.any(),
+  created: z.date().optional(),
+  expires: z.date().nullable().optional(),
+  isAnonymous: z.boolean().optional(),
+  isPublic: z.boolean().optional(),
+  canSubmitMultipleAnswers: z.boolean().optional(),
+});
+
+export default getSurveyEditorFormSchema;

--- a/libs/src/survey/types/editor/getSurveyEditorForm.schema.ts
+++ b/libs/src/survey/types/editor/getSurveyEditorForm.schema.ts
@@ -12,67 +12,56 @@
 
 import { z } from 'zod';
 
-const getSurveyEditorFormSchema = () => z.object({
-  id: z.number(),
-  formula: z.object({
-    title: z.string(),
-    description: z.string().optional(),
-    pages: z.array(
-      z.object({
-        name: z.string(),
-        description: z.string().optional(),
-        elements: z.array(
-          z.object({
-            type: z.string(),
-            name: z.string(),
-            description: z.string().optional(),
-            isRequired: z.boolean().optional(),
-            choices: z
-              .array(
-                z.object({
-                  value: z.string(),
-                  label: z.string(),
-                }),
-              )
-              .optional(),
-            choicesByUrl: z
-              .object({
-                url: z.string(),
-              })
-              .optional(),
-          }),
-        ),
-      }),
-    ),
-  }),
-  backendLimiters: z
-    .array(
-      z.object({
-        questionName: z.string().optional(),
-        choices: z.array(
-          z.object({
-            name: z.string().optional(),
-            title: z.string().optional(),
-            limit: z.number().optional(),
-          }),
-        ),
-      }),
-    )
-    .optional(),
-  saveNo: z.number().optional(),
-  creator: z.intersection(
-    z.object({
-      firstName: z.string().optional(),
-      lastName: z.string().optional(),
-      username: z.string(),
+const getSurveyEditorFormSchema = () =>
+  z.object({
+    id: z.number(),
+    formula: z.object({
+      title: z.string(),
+      description: z.string().optional(),
+      pages: z.array(
+        z.object({
+          name: z.string(),
+          description: z.string().optional(),
+          elements: z.array(
+            z.object({
+              type: z.string(),
+              name: z.string(),
+              description: z.string().optional(),
+              isRequired: z.boolean().optional(),
+              choices: z
+                .array(
+                  z.object({
+                    value: z.string(),
+                    label: z.string(),
+                  }),
+                )
+                .optional(),
+              choicesByUrl: z
+                .object({
+                  url: z.string(),
+                })
+                .optional(),
+            }),
+          ),
+        }),
+      ),
     }),
-    z.object({
-      value: z.string(),
-      label: z.string(),
-    }),
-  ),
-  invitedAttendees: z.array(
-    z.intersection(
+    backendLimiters: z
+      .array(
+        z.object({
+          questionName: z.string().optional(),
+          choices: z.array(
+            z.object({
+              name: z.string().optional(),
+              title: z.string().optional(),
+              limit: z.number().optional(),
+            }),
+          ),
+        }),
+      )
+      .optional(),
+    saveNo: z.number().optional(),
+    creator: z.intersection(
       z.object({
         firstName: z.string().optional(),
         lastName: z.string().optional(),
@@ -83,27 +72,40 @@ const getSurveyEditorFormSchema = () => z.object({
         label: z.string(),
       }),
     ),
-  ),
-  invitedGroups: z.array(z.object({})),
-  participatedAttendees: z.array(
-    z.intersection(
-      z.object({
-        firstName: z.string().optional(),
-        lastName: z.string().optional(),
-        username: z.string(),
-      }),
-      z.object({
-        value: z.string(),
-        label: z.string(),
-      }),
+    invitedAttendees: z.array(
+      z.intersection(
+        z.object({
+          firstName: z.string().optional(),
+          lastName: z.string().optional(),
+          username: z.string(),
+        }),
+        z.object({
+          value: z.string(),
+          label: z.string(),
+        }),
+      ),
     ),
-  ),
-  answers: z.any(),
-  created: z.date().optional(),
-  expires: z.date().nullable().optional(),
-  isAnonymous: z.boolean().optional(),
-  isPublic: z.boolean().optional(),
-  canSubmitMultipleAnswers: z.boolean().optional(),
-});
+    invitedGroups: z.array(z.object({})),
+    participatedAttendees: z.array(
+      z.intersection(
+        z.object({
+          firstName: z.string().optional(),
+          lastName: z.string().optional(),
+          username: z.string(),
+        }),
+        z.object({
+          value: z.string(),
+          label: z.string(),
+        }),
+      ),
+    ),
+    answers: z.any(),
+    created: z.date().optional(),
+    expires: z.date().nullable().optional(),
+    isAnonymous: z.boolean().optional(),
+    isPublic: z.boolean().optional(),
+    canSubmitMultipleAnswers: z.boolean().optional(),
+    canUpdateFormerAnswer: z.boolean().optional(),
+  });
 
 export default getSurveyEditorFormSchema;

--- a/libs/src/survey/types/editor/getSurveyTemplateForm.schema.ts
+++ b/libs/src/survey/types/editor/getSurveyTemplateForm.schema.ts
@@ -13,70 +13,78 @@
 import { z } from 'zod';
 
 const getSurveyTemplateFormSchema = () =>
-z.object({
-  template: z.object({
-    formula: z.object({
-      title: z.string(),
-      description: z.string().optional(),
-      pages: z.array(
-        z.object({
-          name: z.string(),
+  z.object({
+    template: z
+      .object({
+        formula: z.object({
+          title: z.string(),
           description: z.string().optional(),
-          elements: z.array(
+          pages: z.array(
             z.object({
-              type: z.string(),
               name: z.string(),
               description: z.string().optional(),
-              isRequired: z.boolean().optional(),
-              choices: z.array(
+              elements: z.array(
                 z.object({
-                  value: z.string(),
-                  label: z.string(),
+                  type: z.string(),
+                  name: z.string(),
+                  description: z.string().optional(),
+                  isRequired: z.boolean().optional(),
+                  choices: z
+                    .array(
+                      z.object({
+                        value: z.string(),
+                        label: z.string(),
+                      }),
+                    )
+                    .optional(),
+                  choicesByUrl: z
+                    .object({
+                      url: z.string(),
+                    })
+                    .optional(),
                 }),
-              ).optional(),
-              choicesByUrl: z.object({
-                url: z.string(),
-              }).optional(),
+              ),
             }),
           ),
         }),
-      ),
-    }),
-    invitedAttendees: z.array(
-      z.intersection(
-        z.object({
-          firstName: z.string().optional(),
-          lastName: z.string().optional(),
-          username: z.string(),
-        }),
-        z.object({
-          value: z.string(),
-          label: z.string(),
-        }),
-      ),
-    ),
-    backendLimiters: z.array(
-      z.object({
-        questionName: z.string().optional(),
-        choices: z.array(
-          z.object({
-            name: z.string().optional(),
-            title: z.string().optional(),
-            limit: z.number().optional(),
-          }),
+        invitedAttendees: z.array(
+          z.intersection(
+            z.object({
+              firstName: z.string().optional(),
+              lastName: z.string().optional(),
+              username: z.string(),
+            }),
+            z.object({
+              value: z.string(),
+              label: z.string(),
+            }),
+          ),
         ),
-      }),
-    ).optional(),
-    invitedGroups: z.array(z.object({})),
-    isAnonymous: z.boolean().optional(),
-    isPublic: z.boolean().optional(),
-    canSubmitMultipleAnswers: z.boolean().optional(),
-    canUpdateFormerAnswer: z.boolean().optional(),
-    }).optional(),
-  icon: z.string().optional(),
-  isActive: z.boolean(),
-  createdAt: z.date().optional(),
-  updatedAt: z.date().optional(),
-});
+        backendLimiters: z
+          .array(
+            z.object({
+              questionName: z.string().optional(),
+              choices: z.array(
+                z.object({
+                  name: z.string().optional(),
+                  title: z.string().optional(),
+                  limit: z.number().optional(),
+                }),
+              ),
+            }),
+          )
+          .optional(),
+        invitedGroups: z.array(z.object({})),
+        isAnonymous: z.boolean().optional(),
+        isPublic: z.boolean().optional(),
+        canSubmitMultipleAnswers: z.boolean().optional(),
+        canUpdateFormerAnswer: z.boolean().optional(),
+      })
+      .optional(),
+    icon: z.string().optional(),
+    isActive: z.boolean(),
+    createdAt: z.date().optional(),
+    updatedAt: z.date().optional(),
+  });
 
 export default getSurveyTemplateFormSchema;

--- a/libs/src/survey/types/editor/getSurveyTemplateForm.schema.ts
+++ b/libs/src/survey/types/editor/getSurveyTemplateForm.schema.ts
@@ -12,9 +12,9 @@
 
 import { z } from 'zod';
 
-const getSurveyEditorFormSchema = () =>
-  z.object({
-    id: z.number(),
+const getSurveyTemplateFormSchema = () =>
+z.object({
+  template: z.object({
     formula: z.object({
       title: z.string(),
       description: z.string().optional(),
@@ -28,50 +28,20 @@ const getSurveyEditorFormSchema = () =>
               name: z.string(),
               description: z.string().optional(),
               isRequired: z.boolean().optional(),
-              choices: z
-                .array(
-                  z.object({
-                    value: z.string(),
-                    label: z.string(),
-                  }),
-                )
-                .optional(),
-              choicesByUrl: z
-                .object({
-                  url: z.string(),
-                })
-                .optional(),
+              choices: z.array(
+                z.object({
+                  value: z.string(),
+                  label: z.string(),
+                }),
+              ).optional(),
+              choicesByUrl: z.object({
+                url: z.string(),
+              }).optional(),
             }),
           ),
         }),
       ),
     }),
-    backendLimiters: z
-      .array(
-        z.object({
-          questionName: z.string().optional(),
-          choices: z.array(
-            z.object({
-              name: z.string().optional(),
-              title: z.string().optional(),
-              limit: z.number().optional(),
-            }),
-          ),
-        }),
-      )
-      .optional(),
-    saveNo: z.number().optional(),
-    creator: z.intersection(
-      z.object({
-        firstName: z.string().optional(),
-        lastName: z.string().optional(),
-        username: z.string(),
-      }),
-      z.object({
-        value: z.string(),
-        label: z.string(),
-      }),
-    ),
     invitedAttendees: z.array(
       z.intersection(
         z.object({
@@ -85,26 +55,28 @@ const getSurveyEditorFormSchema = () =>
         }),
       ),
     ),
+    backendLimiters: z.array(
+      z.object({
+        questionName: z.string().optional(),
+        choices: z.array(
+          z.object({
+            name: z.string().optional(),
+            title: z.string().optional(),
+            limit: z.number().optional(),
+          }),
+        ),
+      }),
+    ).optional(),
     invitedGroups: z.array(z.object({})),
-    participatedAttendees: z.array(
-      z.intersection(
-        z.object({
-          firstName: z.string().optional(),
-          lastName: z.string().optional(),
-          username: z.string(),
-        }),
-        z.object({
-          value: z.string(),
-          label: z.string(),
-        }),
-      ),
-    ),
-    answers: z.any(),
-    created: z.date().optional(),
-    expires: z.date().nullable().optional(),
     isAnonymous: z.boolean().optional(),
     isPublic: z.boolean().optional(),
     canSubmitMultipleAnswers: z.boolean().optional(),
-  });
+    canUpdateFormerAnswer: z.boolean().optional(),
+    }).optional(),
+  icon: z.string().optional(),
+  isActive: z.boolean(),
+  createdAt: z.date().optional(),
+  updatedAt: z.date().optional(),
+});
 
-export default getSurveyEditorFormSchema;
+export default getSurveyTemplateFormSchema;


### PR DESCRIPTION
Issue: https://github.com/edulution-io/edulution-ui/issues/1142

Copied from korrupted branch #1146 

1142:
* We have decided that we are using the former template folder (`${APPS_FILES_PATH}/${APPS.SURVEYS}/${TEMPLATES}`) as exchange folder.
* migrate templates from files to db
* delete files after migration
* serve templates from db

- [ ] Add a function to delte the templates from the db and to toggle the activation state #1147