### PR TITLE
Reduce maximum file upload size from 400 MB to 50 MB

### DIFF
--- a/apps/frontend/src/locales/de/translation.json
+++ b/apps/frontend/src/locales/de/translation.json
@@ -1361,7 +1361,7 @@
     "folderTooLargeTitle": "Zu viele Dateien im Ordner",
     "folderTooLargeDescription": "Der Ordner enthält mehr als 100 Dateien. Bitte wähle einen anderen Ordner oder reduziere die Anzahl der Dateien.",
     "oversizedFileDetected": "Zu große Datei entdeckt!",
-    "cannotUploadOversized": "Dateien, die größer als 400 MB sind, können nicht hochgeladen werden.",
+    "cannotUploadOversized": "Dateien, die größer als 50 MB sind, können nicht hochgeladen werden.",
     "addFiles": "Dateien hinzufügen",
     "addFolder": "Ordner hinzufügen",
     "preparingFolder": "Ordner wird vorbereitet"

--- a/apps/frontend/src/locales/en/translation.json
+++ b/apps/frontend/src/locales/en/translation.json
@@ -1342,7 +1342,7 @@
   "filesharingUpload": {
     "title": "Upload Files",
     "upload": "Upload",
-    "dataLimitExceeded": "Data limit from 400 MB exceeded",
+    "dataLimitExceeded": "Data limit from 50 MB exceeded",
     "fileSize": "File size",
     "selectFile": "Select up to 5 files at a time",
     "uploadItems": "Upload: {{count}} items",
@@ -1357,7 +1357,7 @@
     "oversizedFileDetected": "Oversized file detected!",
     "folderTooLargeTitle": "Too many files in the folder",
     "folderTooLargeDescription": "The folder contains more then 100 files. Please select another folder or reduce the number of files.",
-    "cannotUploadOversized": "Files larger than 400 MB cannot be uploaded.",
+    "cannotUploadOversized": "Files larger than 50 MB cannot be uploaded.",
     "addFiles": "Add files",
     "addFolder": "Add folder",
     "preparingFolder": "Preparing folder"

--- a/libs/src/ui/constants/maxFileUploadSize.ts
+++ b/libs/src/ui/constants/maxFileUploadSize.ts
@@ -10,5 +10,5 @@
  * You should have received a copy of the GNU Affero General Public License along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
-const MAX_FILE_UPLOAD_SIZE = 400; // MB
+const MAX_FILE_UPLOAD_SIZE = 50; // MB
 export default MAX_FILE_UPLOAD_SIZE;


### PR DESCRIPTION
To prevent LMN from crashing, the upload limit has been reduced back to 50 MB.