### PR TITLE
Add "Save as .tldraw file" functionality to the whiteboard

### DIFF
--- a/apps/frontend/src/locales/de/translation.json
+++ b/apps/frontend/src/locales/de/translation.json
@@ -1375,7 +1375,8 @@
   },
   "whiteboard": {
     "title": "WHITEBOARD",
-    "sidebar": "Whiteboard"
+    "sidebar": "Whiteboard",
+    "saveAsTlFile": "Whiteboard als .tldraw Datei speichern"
   },
   "whiteboard-collaboration": {
     "title": "WHITEBOARD",

--- a/apps/frontend/src/locales/en/translation.json
+++ b/apps/frontend/src/locales/en/translation.json
@@ -1371,7 +1371,8 @@
   },
   "whiteboard": {
     "title": "WHITEBOARD",
-    "sidebar": "Whiteboard"
+    "sidebar": "Whiteboard",
+    "saveAsTlFile": "Save Whiteboard as.tldraw file"
   },
   "whiteboard-collaboration": {
     "title": "WHITEBOARD",

--- a/apps/frontend/src/pages/Whiteboard/TLDrawOffline.tsx
+++ b/apps/frontend/src/pages/Whiteboard/TLDrawOffline.tsx
@@ -15,6 +15,7 @@ import COLOR_SCHEME from '@libs/ui/constants/colorScheme';
 import { Editor } from 'tldraw';
 import useLanguage from '@/hooks/useLanguage';
 import TLDRAW_PERSISTENCE_KEY from '@libs/whiteboard/constants/tldrawPersistenceKey';
+import tlDrawComponents from '@/pages/Whiteboard/components/tlDrawComponents';
 
 const TLDraw = lazy(() =>
   Promise.all([import('tldraw'), import('tldraw/tldraw.css')]).then(([module]) => ({
@@ -33,6 +34,7 @@ const TlDrawOffline = () => {
     <TLDraw
       onMount={handleMount}
       persistenceKey={TLDRAW_PERSISTENCE_KEY}
+      components={tlDrawComponents}
     />
   );
 };

--- a/apps/frontend/src/pages/Whiteboard/TLDrawWithSync.tsx
+++ b/apps/frontend/src/pages/Whiteboard/TLDrawWithSync.tsx
@@ -25,6 +25,7 @@ import useLanguage from '@/hooks/useLanguage';
 import { useTranslation } from 'react-i18next';
 import EDU_API_WEBSOCKET_URL from '@libs/common/constants/eduApiWebsocketUrl';
 import ROOM_ID_PARAM from '@libs/tldraw-sync/constants/roomIdParam';
+import tlDrawComponents from '@/pages/Whiteboard/components/tlDrawComponents';
 
 const TldrawWithSync = () => {
   const { user, eduApiToken } = useUserStore();
@@ -136,6 +137,7 @@ const TldrawWithSync = () => {
         registerDeleteHandler(editor);
       }}
       store={store}
+      components={tlDrawComponents}
     />
   );
 };

--- a/apps/frontend/src/pages/Whiteboard/components/CustomMainTLDrawMenu.tsx
+++ b/apps/frontend/src/pages/Whiteboard/components/CustomMainTLDrawMenu.tsx
@@ -1,0 +1,27 @@
+/*
+ * LICENSE
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import React from 'react';
+import { DefaultMainMenu, DefaultMainMenuContent, TldrawUiMenuGroup } from 'tldraw';
+import SaveAsTldrItem from '@/pages/Whiteboard/components/SaveAsTldrItem';
+
+const CustomMainTLDrawMenu = () => (
+    <DefaultMainMenu>
+      <TldrawUiMenuGroup id="file">
+        <SaveAsTldrItem />
+      </TldrawUiMenuGroup>
+
+      <DefaultMainMenuContent />
+    </DefaultMainMenu>
+  );
+
+export default CustomMainTLDrawMenu;

--- a/apps/frontend/src/pages/Whiteboard/components/SaveAsTldrItem.tsx
+++ b/apps/frontend/src/pages/Whiteboard/components/SaveAsTldrItem.tsx
@@ -1,0 +1,40 @@
+/*
+ * LICENSE
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import React from 'react';
+import { TldrawUiMenuItem, useEditor } from 'tldraw';
+import 'tldraw/tldraw.css';
+import { useTranslation } from 'react-i18next';
+
+const SaveAsTldrItem = () => {
+  const editor = useEditor();
+  const { t } = useTranslation();
+  return (
+    <TldrawUiMenuItem
+      id="saveAsTldr"
+      label={t('whiteboard.saveAsTlFile')}
+      readonlyOk
+      onSelect={() => {
+        const snapshot = editor.store.getSnapshot();
+        const blob = new Blob([JSON.stringify(snapshot, null, 2)], { type: 'application/json' });
+        const url = URL.createObjectURL(blob);
+        const a = document.createElement('a');
+        a.href = url;
+        a.download = `whiteboard-${new Date().toISOString().slice(0, 10)}.tldr`;
+        a.click();
+        URL.revokeObjectURL(url);
+      }}
+    />
+  );
+};
+
+export default SaveAsTldrItem;

--- a/apps/frontend/src/pages/Whiteboard/components/tlDrawComponents.ts
+++ b/apps/frontend/src/pages/Whiteboard/components/tlDrawComponents.ts
@@ -1,0 +1,20 @@
+/*
+ * LICENSE
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import { TLComponents } from 'tldraw';
+import CustomMainTLDrawMenu from '@/pages/Whiteboard/components/SaveAsTldrItem';
+
+const tlDrawComponents: TLComponents = {
+  MainMenu: CustomMainTLDrawMenu,
+};
+
+export default tlDrawComponents;


### PR DESCRIPTION
- The possibility has been added to save a whiteboard as a TLDRAW file. This PR is the basis for introducing interoperability between FM and Whiteboard. In future, we should save those files in FM to recover all whiteboards again. 