### PR TITLE
BulletinBoard: Store bulletin collapsed state in the database

### DIFF
--- a/apps/api/src/app/app.module.ts
+++ b/apps/api/src/app/app.module.ts
@@ -50,6 +50,7 @@ import LdapKeycloakSyncModule from '../ldap-keycloak-sync/ldap-keycloak-sync.mod
 import redisConnection from '../common/redis.connection';
 import NotificationsModule from '../notifications/notifications.module';
 import MobileAppModuleModule from '../mobileAppModule/mobileAppModule.module';
+import UserPreferencesModule from '../user-preferences/user-preferences.module';
 
 @Module({
   imports: [
@@ -89,6 +90,7 @@ import MobileAppModuleModule from '../mobileAppModule/mobileAppModule.module';
     LdapKeycloakSyncModule,
     NotificationsModule,
     MobileAppModuleModule,
+    UserPreferencesModule,
     JwtModule.register({
       global: true,
     }),

--- a/apps/api/src/bulletin-category/bulletin-category.service.ts
+++ b/apps/api/src/bulletin-category/bulletin-category.service.ts
@@ -129,6 +129,7 @@ class BulletinCategoryService implements OnModuleInit {
   async create(currentUser: JWTUser, dto: CreateBulletinCategoryDto) {
     const category = (await this.bulletinCategoryModel.create({
       name: dto.name,
+      bulletinVisibility: dto.bulletinVisibility,
       isActive: dto.isActive ?? true,
       visibleForUsers: dto.visibleForUsers ?? [],
       visibleForGroups: dto.visibleForGroups ?? [],

--- a/apps/api/src/bulletinboard/bulletinboard.module.ts
+++ b/apps/api/src/bulletinboard/bulletinboard.module.ts
@@ -18,6 +18,7 @@ import BulletinBoardService from './bulletinboard.service';
 import { BulletinCategory, BulletinCategorySchema } from '../bulletin-category/bulletin-category.schema';
 import BulletinCategoryModule from '../bulletin-category/bulletin-category.module';
 import GroupsModule from '../groups/groups.module';
+import UserPreferencesModule from '../user-preferences/user-preferences.module';
 
 @Module({
   imports: [
@@ -25,6 +26,7 @@ import GroupsModule from '../groups/groups.module';
     MongooseModule.forFeature([{ name: BulletinCategory.name, schema: BulletinCategorySchema }]),
     BulletinCategoryModule,
     GroupsModule,
+    UserPreferencesModule,
   ],
   controllers: [BulletinBoardController],
   providers: [BulletinBoardService],

--- a/apps/api/src/notifications/notifications.service.ts
+++ b/apps/api/src/notifications/notifications.service.ts
@@ -17,7 +17,7 @@ import SendPushNotificationDto from '@libs/notification/types/send-pushNotificat
 import UsersService from '../users/users.service';
 
 @Injectable()
-export class NotificationsService {
+class NotificationsService {
   private readonly expo = new Expo();
 
   constructor(private userService: UsersService) {}

--- a/apps/api/src/user-preferences/user-preferences.controller.ts
+++ b/apps/api/src/user-preferences/user-preferences.controller.ts
@@ -20,19 +20,19 @@ import UserPreferencesService from './user-preferences.service';
 @Controller(USER_PREFERENCES_ENDPOINT)
 @ApiBearerAuth()
 class UserPreferencesController {
-  constructor(private readonly service: UserPreferencesService) {}
+  constructor(private readonly userPreferencesService: UserPreferencesService) {}
 
   @Get()
   async getPreferences(@GetCurrentUsername() currentUsername: string, @Query('fields') fields: string) {
-    return this.service.getForUser(currentUsername, fields);
+    return this.userPreferencesService.getForUser(currentUsername, fields);
   }
 
   @Patch('bulletin-collapsed')
   async updateBulletinCollapsed(
     @GetCurrentUsername() currentUsername: string,
-    @Body() dto: UpdateBulletinCollapsedDto,
+    @Body() updateBulletinCollapsedDto: UpdateBulletinCollapsedDto,
   ) {
-    return this.service.updateBulletinCollapsedState(currentUsername, dto);
+    return this.userPreferencesService.updateBulletinCollapsedState(currentUsername, updateBulletinCollapsedDto);
   }
 }
 

--- a/apps/api/src/user-preferences/user-preferences.controller.ts
+++ b/apps/api/src/user-preferences/user-preferences.controller.ts
@@ -1,0 +1,39 @@
+/*
+ * LICENSE
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import { Body, Controller, Get, Patch, Query } from '@nestjs/common';
+import { ApiBearerAuth } from '@nestjs/swagger';
+import UpdateBulletinCollapsedDto from '@libs/user-preferences/types/update-bulletin-collapsed.dto';
+import USER_PREFERENCES_ENDPOINT from '@libs/user-preferences/constants/user-preferences-endpoint';
+import GetCurrentUsername from '../common/decorators/getCurrentUsername.decorator';
+import UserPreferencesService from './user-preferences.service';
+
+@Controller(USER_PREFERENCES_ENDPOINT)
+@ApiBearerAuth()
+class UserPreferencesController {
+  constructor(private readonly service: UserPreferencesService) {}
+
+  @Get()
+  async getPreferences(@GetCurrentUsername() currentUsername: string, @Query('fields') fields: string) {
+    return this.service.getForUser(currentUsername, fields);
+  }
+
+  @Patch('bulletin-collapsed')
+  async updateBulletinCollapsed(
+    @GetCurrentUsername() currentUsername: string,
+    @Body() dto: UpdateBulletinCollapsedDto,
+  ) {
+    return this.service.updateBulletinCollapsedState(currentUsername, dto);
+  }
+}
+
+export default UserPreferencesController;

--- a/apps/api/src/user-preferences/user-preferences.module.ts
+++ b/apps/api/src/user-preferences/user-preferences.module.ts
@@ -1,0 +1,25 @@
+/*
+ * LICENSE
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import { Module } from '@nestjs/common';
+import { MongooseModule } from '@nestjs/mongoose';
+import { UserPreferences, UserPreferencesSchema } from './user-preferences.schema';
+import UserPreferencesService from './user-preferences.service';
+import UserPreferencesController from './user-preferences.controller';
+
+@Module({
+  imports: [MongooseModule.forFeature([{ name: UserPreferences.name, schema: UserPreferencesSchema }])],
+  providers: [UserPreferencesService],
+  controllers: [UserPreferencesController],
+  exports: [UserPreferencesService],
+})
+export default class UserPreferencesModule {}

--- a/apps/api/src/user-preferences/user-preferences.schema.ts
+++ b/apps/api/src/user-preferences/user-preferences.schema.ts
@@ -1,0 +1,31 @@
+/*
+ * LICENSE
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import { Prop, Schema, SchemaFactory } from '@nestjs/mongoose';
+import { Document } from 'mongoose';
+
+export type UserPreferencesDocument = UserPreferences & Document;
+
+@Schema({ timestamps: true })
+export class UserPreferences extends Document {
+  @Prop({ type: String, required: true, unique: true, index: true })
+  username: string;
+
+  @Prop({
+    type: Map,
+    of: Boolean,
+    default: {},
+  })
+  collapsedBulletins: Record<string, boolean>;
+}
+
+export const UserPreferencesSchema = SchemaFactory.createForClass(UserPreferences);

--- a/apps/api/src/user-preferences/user-preferences.service.ts
+++ b/apps/api/src/user-preferences/user-preferences.service.ts
@@ -1,0 +1,63 @@
+/*
+ * LICENSE
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import { Injectable } from '@nestjs/common';
+import { InjectModel } from '@nestjs/mongoose';
+import { Model } from 'mongoose';
+import USER_PREFERENCES_FIELDS from '@libs/user-preferences/constants/user-preferences-fields';
+import fieldsToProjection from '@libs/common/utils/fieldsToProjection';
+import UpdateBulletinCollapsedDto from '@libs/user-preferences/types/update-bulletin-collapsed.dto';
+import { UserPreferences, UserPreferencesDocument } from './user-preferences.schema';
+
+@Injectable()
+class UserPreferencesService {
+  constructor(@InjectModel(UserPreferences.name) private readonly model: Model<UserPreferencesDocument>) {}
+
+  async getForUser(username: string, fields: string) {
+    const projection = fieldsToProjection(fields);
+
+    const doc = await this.model
+      .findOne({ username })
+      .select({ ...projection, _id: 0 })
+      .lean();
+
+    return {
+      collapsedBulletins: doc?.collapsedBulletins ?? {},
+    };
+  }
+
+  async updateBulletinCollapsedState(username: string, updateDto: UpdateBulletinCollapsedDto) {
+    return this.model
+      .findOneAndUpdate(
+        { username },
+        { $set: { [`${USER_PREFERENCES_FIELDS.collapsedBulletins}.${updateDto.bulletinId}`]: updateDto.collapsed } },
+        { new: true, upsert: true },
+      )
+      .lean();
+  }
+
+  async unsetCollapsedForBulletins(bulletinIds: string[]): Promise<void> {
+    if (!bulletinIds?.length) return;
+
+    const unsetObj = Object.fromEntries(
+      bulletinIds.map((id) => [`${USER_PREFERENCES_FIELDS.collapsedBulletins}.${id}`, 1]),
+    );
+
+    const filter = {
+      $or: bulletinIds.map((id) => ({ [`${USER_PREFERENCES_FIELDS.collapsedBulletins}.${id}`]: { $exists: true } })),
+    };
+
+    await this.model.updateMany(filter, { $unset: unsetObj }).exec();
+  }
+}
+
+export default UserPreferencesService;

--- a/apps/api/src/user-preferences/user-preferences.service.ts
+++ b/apps/api/src/user-preferences/user-preferences.service.ts
@@ -20,12 +20,14 @@ import { UserPreferences, UserPreferencesDocument } from './user-preferences.sch
 
 @Injectable()
 class UserPreferencesService {
-  constructor(@InjectModel(UserPreferences.name) private readonly model: Model<UserPreferencesDocument>) {}
+  constructor(
+    @InjectModel(UserPreferences.name) private readonly userPreferencesModel: Model<UserPreferencesDocument>,
+  ) {}
 
   async getForUser(username: string, fields: string) {
     const projection = fieldsToProjection(fields);
 
-    const doc = await this.model
+    const doc = await this.userPreferencesModel
       .findOne({ username })
       .select({ ...projection, _id: 0 })
       .lean();
@@ -36,7 +38,7 @@ class UserPreferencesService {
   }
 
   async updateBulletinCollapsedState(username: string, updateDto: UpdateBulletinCollapsedDto) {
-    return this.model
+    return this.userPreferencesModel
       .findOneAndUpdate(
         { username },
         { $set: { [`${USER_PREFERENCES_FIELDS.collapsedBulletins}.${updateDto.bulletinId}`]: updateDto.collapsed } },
@@ -56,7 +58,7 @@ class UserPreferencesService {
       $or: bulletinIds.map((id) => ({ [`${USER_PREFERENCES_FIELDS.collapsedBulletins}.${id}`]: { $exists: true } })),
     };
 
-    await this.model.updateMany(filter, { $unset: unsetObj }).exec();
+    await this.userPreferencesModel.updateMany(filter, { $unset: unsetObj }).exec();
   }
 }
 

--- a/apps/frontend/src/pages/BulletinBoard/BulletinBoardPage.tsx
+++ b/apps/frontend/src/pages/BulletinBoard/BulletinBoardPage.tsx
@@ -21,6 +21,8 @@ import BulletinBoardPageColumn from '@/pages/BulletinBoard/components/BulletinBo
 import useBulletinBoardEditorialStore from '@/pages/BulletinBoard/BulletinBoardEditorial/useBulletinBoardEditorialStore';
 import PageLayout from '@/components/structure/layout/PageLayout';
 import CreateOrUpdateBulletinDialog from '@/pages/BulletinBoard/BulletinBoardEditorial/CreateOrUpdateBulletinDialog';
+import useUserPreferencesStore from '@/store/useUserPreferencesStore';
+import USER_PREFERENCES_FIELDS from '@libs/user-preferences/constants/user-preferences-fields';
 
 const BulletinBoardPage = () => {
   const { t } = useTranslation();
@@ -30,19 +32,37 @@ const BulletinBoardPage = () => {
     getBulletinsByCategories,
     isLoading,
     isEditorialModeEnabled,
+    hydrateCollapsed,
   } = useBulletinBoardStore();
+
+  const { getUserPreferences } = useUserPreferencesStore();
   const { getCategoriesWithEditPermission } = useBulletinBoardEditorialStore();
   const [isInitialLoading, setIsInitialLoading] = useState<boolean>(true);
 
   useEffect(() => {
     const fetchData = async () => {
+      const userPreferences = await getUserPreferences([USER_PREFERENCES_FIELDS.collapsedBulletins]);
+
+      if (userPreferences?.collapsedBulletins) {
+        hydrateCollapsed(userPreferences.collapsedBulletins);
+      } else {
+        hydrateCollapsed({});
+      }
+
       void getCategoriesWithEditPermission();
       await getBulletinsByCategories(false);
       setIsInitialLoading(false);
     };
 
     void fetchData();
-  }, [isEditorialModeEnabled, bulletinBoardNotifications]);
+  }, [
+    isEditorialModeEnabled,
+    bulletinBoardNotifications,
+    getUserPreferences,
+    hydrateCollapsed,
+    getBulletinsByCategories,
+    getCategoriesWithEditPermission,
+  ]);
 
   const getPageContent = () => {
     if (isEditorialModeEnabled) {

--- a/apps/frontend/src/pages/BulletinBoard/components/BulletinBoardColumnItem.tsx
+++ b/apps/frontend/src/pages/BulletinBoard/components/BulletinBoardColumnItem.tsx
@@ -60,7 +60,7 @@ const BulletinBoardColumnItem = ({
       const shouldBeCollapsed =
         (initialBulletinVisibility ?? BULLETIN_VISIBILITY_STATES.FULLY_VISIBLE) !==
         BULLETIN_VISIBILITY_STATES.FULLY_VISIBLE;
-      setCollapsed(bulletin.id, shouldBeCollapsed);
+      void setCollapsed(bulletin.id, shouldBeCollapsed);
     }
   }, [bulletin.id, collapsedMap, initialBulletinVisibility, setCollapsed]);
 

--- a/apps/frontend/src/store/useUserPreferencesStore.ts
+++ b/apps/frontend/src/store/useUserPreferencesStore.ts
@@ -1,0 +1,47 @@
+/*
+ * LICENSE
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import { create } from 'zustand';
+import eduApi from '@/api/eduApi';
+import USER_PREFERENCES_ENDPOINT from '@libs/user-preferences/constants/user-preferences-endpoint';
+import UserPreferencesDto from '@libs/user-preferences/types/user-preferences.dto';
+import handleApiError from '@/utils/handleApiError';
+
+interface UserPreferencesStore {
+  isLoading: boolean;
+  error: Error | null;
+  preferences: UserPreferencesDto | null;
+  getUserPreferences: (fields: string[]) => Promise<UserPreferencesDto | null>;
+}
+
+const useUserPreferencesStore = create<UserPreferencesStore>((set) => ({
+  isLoading: false,
+  error: null,
+  preferences: null,
+
+  getUserPreferences: async (fields) => {
+    set({ isLoading: true, error: null });
+    try {
+      const { data } = await eduApi.get<UserPreferencesDto>(`${USER_PREFERENCES_ENDPOINT}?fields=${fields.join(',')}`);
+      set({ preferences: data, isLoading: false });
+
+      return data;
+    } catch (error) {
+      handleApiError(error, set);
+      return null;
+    } finally {
+      set({ isLoading: false });
+    }
+  },
+}));
+
+export default useUserPreferencesStore;

--- a/libs/src/common/utils/fieldsToProjection.ts
+++ b/libs/src/common/utils/fieldsToProjection.ts
@@ -1,0 +1,33 @@
+/*
+ * LICENSE
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+export type Projection = Record<string, 0 | 1>;
+
+const fieldsToProjection = (fields: string): Projection => {
+  const fieldsArray = (fields ?? '')
+    .split(',')
+    .map((f) => f.trim())
+    .filter(Boolean);
+
+  return fieldsArray
+    .map((s) => s.trim())
+    .filter(Boolean)
+    .reduce<Projection>(
+      (acc, key) => {
+        acc[key] = 1;
+        return acc;
+      },
+      { _id: 0 },
+    );
+};
+
+export default fieldsToProjection;

--- a/libs/src/user-preferences/constants/user-preferences-endpoint.ts
+++ b/libs/src/user-preferences/constants/user-preferences-endpoint.ts
@@ -1,0 +1,15 @@
+/*
+ * LICENSE
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+const USER_PREFERENCES_ENDPOINT = 'user-preferences';
+
+export default USER_PREFERENCES_ENDPOINT;

--- a/libs/src/user-preferences/constants/user-preferences-fields.ts
+++ b/libs/src/user-preferences/constants/user-preferences-fields.ts
@@ -1,0 +1,17 @@
+/*
+ * LICENSE
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+const USER_PREFERENCES_FIELDS = {
+  collapsedBulletins: 'collapsedBulletins',
+} as const;
+
+export default USER_PREFERENCES_FIELDS;

--- a/libs/src/user-preferences/types/update-bulletin-collapsed.dto.ts
+++ b/libs/src/user-preferences/types/update-bulletin-collapsed.dto.ts
@@ -1,0 +1,15 @@
+/*
+ * LICENSE
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+type UpdateBulletinCollapsedDto = { bulletinId: string; collapsed: boolean };
+
+export default UpdateBulletinCollapsedDto;

--- a/libs/src/user-preferences/types/user-preferences.dto.ts
+++ b/libs/src/user-preferences/types/user-preferences.dto.ts
@@ -1,0 +1,18 @@
+/*
+ * LICENSE
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+interface UserPreferencesDto {
+  username: string;
+  collapsedBulletins: Record<string, boolean>;
+}
+
+export default UserPreferencesDto;


### PR DESCRIPTION
Added a new `userPreferences` collection (can be extended later).
Updates the collapsed state of bulletins per user in the database.

Additionally fixed a bug where the initial bulletin category visibility was not set.