### PR TITLE
ClassManagement: Fix bugs with printing passwords as admin

### DIFF
--- a/apps/frontend/src/pages/ClassManagement/PasswordsPage/ClassList/ClassList.tsx
+++ b/apps/frontend/src/pages/ClassManagement/PasswordsPage/ClassList/ClassList.tsx
@@ -21,9 +21,10 @@ interface EnrolGroupListProps {
   row: GroupColumn;
   selectedClasses: LmnApiSchoolClass[];
   setSelectedClasses: React.Dispatch<React.SetStateAction<LmnApiSchoolClass[]>>;
+  activeSchool: string | null;
 }
 
-const ClassList = ({ row, selectedClasses, setSelectedClasses }: EnrolGroupListProps) => {
+const ClassList = ({ row, selectedClasses, setSelectedClasses, activeSchool }: EnrolGroupListProps) => {
   const { t } = useTranslation();
 
   return (
@@ -35,6 +36,7 @@ const ClassList = ({ row, selectedClasses, setSelectedClasses }: EnrolGroupListP
             group={group as LmnApiSchoolClass}
             selectedClasses={selectedClasses}
             setSelectedClasses={setSelectedClasses}
+            disabled={!!activeSchool && (group as LmnApiSchoolClass).sophomorixSchoolname !== activeSchool}
           />
         ))
       ) : (

--- a/apps/frontend/src/pages/ClassManagement/PasswordsPage/ClassList/ClassListCard.tsx
+++ b/apps/frontend/src/pages/ClassManagement/PasswordsPage/ClassList/ClassListCard.tsx
@@ -27,9 +27,10 @@ interface ClassListCardProps {
   group: LmnApiSchoolClass;
   selectedClasses: LmnApiSchoolClass[];
   setSelectedClasses: React.Dispatch<React.SetStateAction<LmnApiSchoolClass[]>>;
+  disabled?: boolean;
 }
 
-const ClassListCard = ({ selectedClasses, setSelectedClasses, group }: ClassListCardProps) => {
+const ClassListCard = ({ selectedClasses, setSelectedClasses, group, disabled }: ClassListCardProps) => {
   const { user } = useLmnApiStore();
   const { displayName, cn: commonName, sophomorixSchoolname } = group;
   const [isHovered, setIsHovered] = useState<boolean>(false);
@@ -43,6 +44,8 @@ const ClassListCard = ({ selectedClasses, setSelectedClasses, group }: ClassList
   const isSelected = !!selectedClasses.find((s) => s.dn === group.dn);
 
   const toggleIsSelected = () => {
+    if (disabled) return;
+
     if (isSelected) {
       setSelectedClasses((prev) => prev.filter((p) => p.dn !== group.dn));
     } else {
@@ -70,7 +73,7 @@ const ClassListCard = ({ selectedClasses, setSelectedClasses, group }: ClassList
         className={cn(
           'h-13 my-2 ml-1 mr-8 flex w-64 min-w-64 overflow-hidden ',
           isActive && 'scale-105',
-          'cursor-pointer',
+          disabled ? 'cursor-not-allowed opacity-50' : 'cursor-pointer',
         )}
         onClick={onSelect}
         onMouseOver={() => setIsHovered(true)}

--- a/apps/frontend/src/pages/ClassManagement/PasswordsPage/PrintPasswordsDialog.tsx
+++ b/apps/frontend/src/pages/ClassManagement/PasswordsPage/PrintPasswordsDialog.tsx
@@ -18,7 +18,6 @@ import PrintPasswordsFormat from '@libs/classManagement/types/printPasswordsForm
 import Checkbox from '@/components/ui/Checkbox';
 import DEFAULT_SCHOOL from '@libs/lmnApi/constants/defaultSchool';
 import usePrintPasswordsStore from '@/pages/ClassManagement/PasswordsPage/usePrintPasswordsStore';
-import useLmnApiStore from '@/store/useLmnApiStore';
 import CircleLoader from '@/components/ui/Loading/CircleLoader';
 import DialogFooterButtons from '@/components/ui/DialogFooterButtons';
 
@@ -29,17 +28,18 @@ interface PrintPasswordsDialogProps {
 }
 
 const PrintPasswordsDialog: React.FC<PrintPasswordsDialogProps> = ({ selectedClasses, title, onClose }) => {
-  const { user } = useLmnApiStore();
   const { printPasswords, isLoading } = usePrintPasswordsStore();
   const [isPdfLatexSelected, setIsPdfLatexSelected] = useState<boolean>(false);
   const [isOneItemPerPageSelected, setIsOneItemPerPageSelected] = useState<boolean>(false);
 
   const handelConfirm = async () => {
+    const school = selectedClasses.length > 0 ? selectedClasses[0].sophomorixSchoolname : DEFAULT_SCHOOL;
+
     switch (title) {
       case PrintPasswordsFormat.PDF:
         await printPasswords({
           format: PrintPasswordsFormat.PDF,
-          school: user?.school || DEFAULT_SCHOOL,
+          school,
           pdflatex: isPdfLatexSelected,
           one_per_page: isOneItemPerPageSelected,
           schoolclasses: selectedClasses.map((m) => m.cn),
@@ -49,7 +49,7 @@ const PrintPasswordsDialog: React.FC<PrintPasswordsDialogProps> = ({ selectedCla
       default:
         await printPasswords({
           format: PrintPasswordsFormat.CSV,
-          school: user?.school || DEFAULT_SCHOOL,
+          school,
           pdflatex: false,
           one_per_page: false,
           schoolclasses: selectedClasses.map((m) => m.cn),

--- a/apps/frontend/src/pages/ClassManagement/PasswordsPage/usePrintPasswordsStore.ts
+++ b/apps/frontend/src/pages/ClassManagement/PasswordsPage/usePrintPasswordsStore.ts
@@ -17,7 +17,8 @@ import useLmnApiStore from '@/store/useLmnApiStore';
 import LMN_API_EDU_API_ENDPOINTS from '@libs/lmnApi/constants/eduApiEndpoints';
 import PrintPasswordsStore from '@libs/classManagement/types/store/printPasswordsStore';
 import PrintPasswordsRequest from '@libs/classManagement/types/printPasswordsRequest';
-import { HTTP_HEADERS, ResponseType } from '@libs/common/types/http-methods';
+import { HTTP_HEADERS, RequestResponseContentType, ResponseType } from '@libs/common/types/http-methods';
+import PrintPasswordsFormat from '@libs/classManagement/types/printPasswordsFormat';
 
 const initialState = {
   isLoading: false,
@@ -31,28 +32,33 @@ const usePrintPasswordsStore = create<PrintPasswordsStore>((set) => ({
     set({ error: null, isLoading: true });
     try {
       const { lmnApiToken } = useLmnApiStore.getState();
-      const response = await eduApi.post<Blob>(
+      const response = await eduApi.post<ArrayBuffer>(
         LMN_API_EDU_API_ENDPOINTS.PRINT_PASSWORDS,
-        {
-          options,
-        },
+        { options },
         {
           headers: { [HTTP_HEADERS.XApiKey]: lmnApiToken },
-          responseType: ResponseType.BLOB,
+          responseType: ResponseType.ARRAYBUFFER,
         },
       );
 
-      const url = window.URL.createObjectURL(response.data);
-      const link = document.createElement('a');
-      link.href = url;
+      const mimeType =
+        options.format === PrintPasswordsFormat.CSV
+          ? `${RequestResponseContentType.TEXT_CSV};charset=utf-8;`
+          : RequestResponseContentType.APPLICATION_PDF;
+
+      const blob = new Blob([response.data], { type: mimeType });
+      const url = window.URL.createObjectURL(blob);
 
       const filename = `${options.schoolclasses.join('-')}-${options.school}-passwords.${options.format}`;
+
+      const link = document.createElement('a');
+      link.href = url;
       link.setAttribute('download', filename);
 
       document.body.appendChild(link);
       link.click();
-
       link.parentNode?.removeChild(link);
+
       window.URL.revokeObjectURL(url);
     } catch (error) {
       handleApiError(error, set);

--- a/libs/src/common/types/http-methods.ts
+++ b/libs/src/common/types/http-methods.ts
@@ -41,6 +41,7 @@ export enum RequestResponseContentType {
   APPLICATION_PDF = 'application/pdf',
   APPLICATION_X_WWW_FORM_URLENCODED = 'application/x-www-form-urlencoded',
   TEXT_PLAIN = 'text/plain',
+  TEXT_CSV = 'text/csv',
   MULTIPART_FORM_DATA = 'multipart/form-data',
   APPLICATION_OCTET_STREAM = 'application/octet-stream',
   APPLICATION_GITHUB_RAW = 'application/vnd.github.v3.raw',


### PR DESCRIPTION
- Allow multiple selection for printing passwords only for the same school (otherwise it fails)
- Send the `school` correctly
- Show a loading indicator when loading printable classes
- Show all classes for admins
- Fix the file type of the downloaded CSV (before the browser interpreted it as PDF)