### PR TITLE
ClassManagement: Fix bugs on lesson page

### DIFF
--- a/apps/api/src/lmnApi/lmnApi.service.ts
+++ b/apps/api/src/lmnApi/lmnApi.service.ts
@@ -539,7 +539,7 @@ class LmnApiService {
           headers: { [HTTP_HEADERS.XApiKey]: lmnApiToken },
         }),
       );
-      const members = response.data.members.filter((member) => response.data.sophomorixMembers.includes(member.cn));
+      const members = response.data.members.filter((member) => response.data.all_members.includes(member.cn));
       return { ...response.data, members };
     } catch (error) {
       throw new CustomHttpException(

--- a/apps/frontend/src/pages/ClassManagement/LessonPage/QuickAccess/GroupCard.tsx
+++ b/apps/frontend/src/pages/ClassManagement/LessonPage/QuickAccess/GroupCard.tsx
@@ -21,7 +21,6 @@ import { useNavigate } from 'react-router-dom';
 import { CLASS_MANAGEMENT_LESSON_PATH } from '@libs/classManagement/constants/classManagementPaths';
 import LmnApiSchoolClass from '@libs/lmnApi/types/lmnApiSchoolClass';
 import LmnApiProject from '@libs/lmnApi/types/lmnApiProject';
-import LmnApiSession from '@libs/lmnApi/types/lmnApiSession';
 import STUDENTS_REGEX from '@libs/lmnApi/constants/studentsRegex';
 import removeSchoolPrefix from '@libs/classManagement/utils/removeSchoolPrefix';
 import useLmnApiStore from '@/store/useLmnApiStore';
@@ -29,7 +28,7 @@ import useLmnApiStore from '@/store/useLmnApiStore';
 interface GroupCardProps {
   icon?: ReactElement;
   type: UserGroups;
-  group: LmnApiSession | LmnApiProject | LmnApiSchoolClass;
+  group: LmnApiProject | LmnApiSchoolClass;
 }
 
 const GroupCard = ({ icon, type, group }: GroupCardProps) => {
@@ -42,9 +41,9 @@ const GroupCard = ({ icon, type, group }: GroupCardProps) => {
     return null;
   }
 
-  const member =
-    (group as LmnApiSession).members?.map((m) => m.dn) || (group as LmnApiSchoolClass | LmnApiProject).member;
-  const memberCount = member.filter((m) => STUDENTS_REGEX.test(m))?.length || 0;
+  const {member} = group;
+  const studentsCount = member.filter((m) => STUDENTS_REGEX.test(m))?.length || 0;
+  const otherMembersCount = member.filter((m) => m !== user?.distinguishedName)?.length || 0;
 
   const onCardClick = () => {
     navigate(`/${CLASS_MANAGEMENT_LESSON_PATH}/${type}/${group.name}`);
@@ -82,7 +81,8 @@ const GroupCard = ({ icon, type, group }: GroupCardProps) => {
                   <>{t('classmanagement.startSession')}</>
                 ) : (
                   <>
-                    {memberCount} {t(memberCount === 1 ? 'student' : 'students')}
+                    {studentsCount}
+                    {otherMembersCount > studentsCount && '+'} {t(studentsCount === 1 ? 'student' : 'students')}
                   </>
                 )}
               </p>

--- a/apps/frontend/src/pages/ClassManagement/LessonPage/QuickAccess/GroupsColumn.tsx
+++ b/apps/frontend/src/pages/ClassManagement/LessonPage/QuickAccess/GroupsColumn.tsx
@@ -16,7 +16,6 @@ import GroupCard from '@/pages/ClassManagement/LessonPage/QuickAccess/GroupCard'
 import GroupColumn from '@libs/groups/types/groupColumn';
 import useUserStore from '@/store/UserStore/useUserStore';
 import CircleLoader from '@/components/ui/Loading/CircleLoader';
-import LmnApiSession from '@libs/lmnApi/types/lmnApiSession';
 import LmnApiProject from '@libs/lmnApi/types/lmnApiProject';
 import LmnApiSchoolClass from '@libs/lmnApi/types/lmnApiSchoolClass';
 
@@ -37,7 +36,7 @@ const GroupsColumn = ({ column }: GroupsColumnProps) => {
     <GroupCard
       type={name}
       key={user!.username + group.name}
-      group={group as LmnApiSession | LmnApiProject | LmnApiSchoolClass}
+      group={group as LmnApiProject | LmnApiSchoolClass}
       icon={icon}
     />
   ));


### PR DESCRIPTION
There is a problem with nested groups in LMN. The LMN api only responds with the correct `member` array, if you query it with a special attribute. The problem here is that these requests take a very long time.

- This PR fixes a problem where the LMN api changed (`sophomorixMembers` is no more valid, had to be replaced with `all_members`.
- Additionally we now show a plus `+` when there are nested groups as members of groups when we expect more students in a group:
<img width="467" height="169" alt="grafik" src="https://github.com/user-attachments/assets/11812e02-0820-4e6f-bd4b-d0ef06938e5f" />
