### PR TITLE
Whiteboard: Fix overflowing menu

### DIFF
--- a/apps/frontend/src/index.scss
+++ b/apps/frontend/src/index.scss
@@ -193,7 +193,6 @@ button:hover .ql-fill,
 }
 
 @layer components {
-  [data-radix-popper-content-wrapper] input,
   [data-radix-popper-content-wrapper] [data-testid='people-menu.change-name'] {
     @apply hidden;
   }

--- a/apps/frontend/src/pages/Whiteboard/TLDrawWithSync/TLDrawWithSync.tsx
+++ b/apps/frontend/src/pages/Whiteboard/TLDrawWithSync/TLDrawWithSync.tsx
@@ -167,7 +167,7 @@ const TLDrawWithSync = ({ uri }: { uri: string }) => {
 
       {uri && store && (
         <Tldraw
-          className="z-10"
+          className="z-100"
           onMount={(editor) => {
             setEditor(editor);
             applyUserPreferences(editor);


### PR DESCRIPTION
before
<img width="288" height="208" alt="Bildschirmfoto vom 2025-09-25 14-40-12" src="https://github.com/user-attachments/assets/a5d2c8ec-cab2-4bd4-8e5a-363c43dd2dad" />

after
<img width="288" height="208" alt="Bildschirmfoto vom 2025-09-25 14-39-37" src="https://github.com/user-attachments/assets/e61ae58c-8d56-42f8-ad9e-45d4cc5c05d2" />