### PR TITLE
Fix typo in visibility translation

### DIFF
--- a/apps/frontend/src/locales/en/translation.json
+++ b/apps/frontend/src/locales/en/translation.json
@@ -1184,7 +1184,7 @@
   "edit": "Edit",
   "common": {
     "showMore": "Show more",
-    "visibility": "Vsibility",
+    "visibility": "Visibility",
     "offline": "Offline",
     "guest": "Guest",
     "ok": "OK",


### PR DESCRIPTION
Fixed typo inside the translation for english locale. 
`"visibility": "Vsibility",` should be `"visibility": "Visibility",`