### PR TITLE
Fix: After uploading a file, the file list cannot be refreshed.

### DIFF
--- a/apps/frontend/src/pages/Whiteboard/SaveTldrDialog.tsx
+++ b/apps/frontend/src/pages/Whiteboard/SaveTldrDialog.tsx
@@ -21,12 +21,14 @@ import useFileSharingDialogStore from '@/pages/FileSharing/Dialog/useFileSharing
 import useWhiteboardEditorStore from '@/pages/Whiteboard/useWhiteboardEditorStore';
 import buildTldrFileFromEditor from '@libs/tldraw-sync/utils/buildTldrFileFromEditor';
 import useUserStore from '@/store/UserStore/useUserStore';
+import { UploadFile } from '@libs/filesharing/types/uploadFile';
+import { v4 as uuidv4 } from 'uuid';
 import useFileSharingStore from '../FileSharing/useFileSharingStore';
 
 const SaveTldrDialog: React.FC = () => {
   const { t } = useTranslation();
 
-  const { setFilesToUpload, uploadFiles } = useHandelUploadFileStore();
+  const { updateFilesToUpload, uploadFiles } = useHandelUploadFileStore();
   const { eduApiToken } = useUserStore();
   const { editor, isDialogOpen, setIsDialogOpen } = useWhiteboardEditorStore();
   const { moveOrCopyItemToPath } = useFileSharingDialogStore();
@@ -43,7 +45,14 @@ const SaveTldrDialog: React.FC = () => {
 
   const save = async (file: File | Blob) => {
     const targetDir = moveOrCopyItemToPath?.filePath || '';
-    setFilesToUpload([file as File]);
+    const name = (file as File)?.name && (file as File)?.name.trim() !== '' ? (file as File).name : 'untitled.tldr';
+    const uploadFile: UploadFile = Object.assign(new File([file], name, { type: file.type }), {
+      id: uuidv4(),
+      isZippedFolder: false,
+      originalFolderName: undefined,
+      fileCount: undefined,
+    });
+    updateFilesToUpload(() => [uploadFile]);
     await uploadFiles(targetDir, eduApiToken, selectedWebdavShare);
     setIsDialogOpen(false);
   };

--- a/libs/src/filesharing/types/uploadFile.ts
+++ b/libs/src/filesharing/types/uploadFile.ts
@@ -14,4 +14,5 @@ export type UploadFile = File & {
   isZippedFolder?: boolean;
   originalFolderName?: string;
   fileCount?: number;
+  id: string;
 };

--- a/libs/src/filesharing/utils/createFileUploader.ts
+++ b/libs/src/filesharing/utils/createFileUploader.ts
@@ -23,8 +23,8 @@ export interface CreateFileUploaderDependencies {
   httpClient: AxiosInstance;
   uploadEndpointPath?: string;
   destinationPath: string;
-  onProgressUpdate: (fileName: string, next: FileProgress) => void;
-  onUploadingChange?: (fileName: string, uploading: boolean) => void;
+  onProgressUpdate: (fileItem: UploadFile, next: FileProgress) => void;
+  onUploadingChange?: (fileItem: UploadFile, uploading: boolean) => void;
 }
 
 const createFileUploader = (dependencies: CreateFileUploaderDependencies) => {
@@ -43,10 +43,10 @@ const createFileUploader = (dependencies: CreateFileUploaderDependencies) => {
 
     const progress = createProgressHandler({
       fileSize: fileItem.size,
-      setProgress: (next) => onProgressUpdate(fileName, next),
+      setProgress: (next) => onProgressUpdate(fileItem, next),
     });
 
-    onUploadingChange?.(fileName, true);
+    onUploadingChange?.(fileItem, true);
 
     try {
       progress.markStart();
@@ -62,7 +62,7 @@ const createFileUploader = (dependencies: CreateFileUploaderDependencies) => {
         ok: false,
       };
     } finally {
-      onUploadingChange?.(fileName, false);
+      onUploadingChange?.(fileItem, false);
     }
   };
 };


### PR DESCRIPTION
- Fixed upload params (`name`, `share`, `contentLength`) for WebDAV uploads.
- Added progress tracking per `share` and file `id`.

