### PR TITLE
BulletinBoard: Fix bulletins overflowing on small screens

### DIFF
--- a/apps/frontend/src/pages/BulletinBoard/components/BulletinBoardPageColumn.tsx
+++ b/apps/frontend/src/pages/BulletinBoard/components/BulletinBoardPageColumn.tsx
@@ -52,7 +52,7 @@ const BulletinBoardPageColumn = ({
   return (
     <div
       style={{ width }}
-      className="flex max-h-full w-full min-w-[400px] flex-shrink-0 flex-col rounded-lg pr-2 md:ml-0 md:pr-3 md:pt-3"
+      className="flex max-h-full w-full min-w-[85vw] flex-shrink-0 flex-col rounded-lg pr-2 md:ml-0 md:min-w-[400px] md:pr-3 md:pt-3"
     >
       <BulletinBoardColumnHeader
         category={category}


### PR DESCRIPTION
<img width="392" height="824" alt="Bildschirmfoto vom 2025-10-08 10-43-20" src="https://github.com/user-attachments/assets/be7e93ca-2e02-4819-a128-e9a3b28f32b2" />
